### PR TITLE
[CSL-2160] Update styles to fix layout shift in select

### DIFF
--- a/src/new-styles.css
+++ b/src/new-styles.css
@@ -241,8 +241,6 @@
 .cio-question-option-value {
   text-align: center;
   margin: auto 0;
-  overflow: hidden;
-  display: -webkit-box;
 }
 
 .cio-select-question-buttons {


### PR DESCRIPTION
<img width="710" alt="Screenshot 2023-03-23 at 2 32 58 PM" src="https://user-images.githubusercontent.com/57369888/227368738-03bc3713-d4a6-45aa-931c-2f44b10aee76.png">


Looks not ideal before the first media query because the height doesn't scale anymore but not sure what we can do here 🤷  Any ideas here or is it not worth worrying about. I that will never happen unless people resize the page so 🤔 