### PR TITLE
[CSL-2355] Quizzes in small containers

### DIFF
--- a/.storybook/storybook-styles.css
+++ b/.storybook/storybook-styles.css
@@ -7,3 +7,15 @@
   min-height: 100dvh;
   height: 100dvh;
 }
+
+.small-container-example-wrapper {
+  height: 100%;
+  display: grid;
+  align-content: center;
+}
+
+.small-container-example {
+  height: 600px;
+  width: 70%;
+  margin: auto auto;
+}

--- a/.storybook/storybook-styles.css
+++ b/.storybook/storybook-styles.css
@@ -12,6 +12,7 @@
   height: 100%;
   display: grid;
   align-content: center;
+  background-color: #F8F8F8;
 }
 
 .small-container-example {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,7 +29,7 @@ export const basicDescription = `Pass an \`apiKey\` and a \`quizId\` to request 
 export const cioJsClientDescription = `If you are already using an instance of the \`ConstructorIOClient\`, you can pass a \`cioJsClient\` instead of an \`apiKey\` to request results from Constructor's servers
 
 > Note: \`cioJsClient\` refers to an instance of the [constructorio-client-javascript](https://www.npmjs.com/package/@constructor-io/constructorio-client-javascript)`;
-export const smallContainerDescription = `If you are using the provided styles, CioQuiz component will respect the height and width of it's parent container and use responsive styles based on the parent container's dimensions`;
+export const smallContainerDescription = `If you are using the provided styles, CioQuiz component will respect the height and width of its parent container and use responsive styles based on the parent container's dimensions`;
 
 export enum RequestStates {
   Stale,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,6 +29,7 @@ export const basicDescription = `Pass an \`apiKey\` and a \`quizId\` to request 
 export const cioJsClientDescription = `If you are already using an instance of the \`ConstructorIOClient\`, you can pass a \`cioJsClient\` instead of an \`apiKey\` to request results from Constructor's servers
 
 > Note: \`cioJsClient\` refers to an instance of the [constructorio-client-javascript](https://www.npmjs.com/package/@constructor-io/constructorio-client-javascript)`;
+export const smallContainerDescription = `If you are using the provided styles, CioQuiz component will respect the height and width of it's parent container and use responsive styles based on the parent container's dimensions`;
 
 export enum RequestStates {
   Stale,

--- a/src/stories/Quiz/Component/index.stories.tsx
+++ b/src/stories/Quiz/Component/index.stories.tsx
@@ -9,6 +9,7 @@ import {
   basicDescription,
   componentDescription,
   cioJsClientDescription,
+  smallContainerDescription,
   apiKey,
   quizId,
 } from '../../../constants';
@@ -51,6 +52,26 @@ addComponentStoryDescription(
   basicDescription
 );
 
+function RenderInASmallContainerTemplate(args: IQuizProps) {
+  return (
+    <div className='small-container-example-wrapper'>
+      <div className='small-container-example'>
+        <CioQuiz {...args} />
+      </div>
+    </div>
+  );
+}
+export const RenderInASmallContainer = RenderInASmallContainerTemplate.bind({});
+RenderInASmallContainer.args = { apiKey, quizId, resultsPageOptions };
+addComponentStoryDescription(
+  RenderInASmallContainer,
+  `
+import '@constructor-io/constructorio-ui-quizzes/styles.css';
+
+const args = ${stringifyWithDefaults(BasicUsage.args)}`,
+  smallContainerDescription
+);
+
 const cioJsClient = new ConstructorIOClient({ apiKey });
 
 // The following block is to remove unrelated modules from Storybook's "Controls" panel
@@ -84,15 +105,3 @@ const cioJsClient = new ConstructorIOClient({ apiKey: '${apiKey}' });
 const args = ${stringifyWithDefaults(ProvideCIOClientInstance.args)};`,
   cioJsClientDescription
 );
-
-function RenderInASmallContainerTemplate(args: IQuizProps) {
-  return (
-    <div className='small-container-example-wrapper'>
-      <div className='small-container-example'>
-        <CioQuiz {...args} />
-      </div>
-    </div>
-  );
-}
-export const RenderInASmallContainer = RenderInASmallContainerTemplate.bind({});
-RenderInASmallContainer.args = { apiKey, quizId, resultsPageOptions };

--- a/src/stories/Quiz/Component/index.stories.tsx
+++ b/src/stories/Quiz/Component/index.stories.tsx
@@ -1,6 +1,7 @@
-/* eslint-disable no-console */
+/* eslint-disable no-console, react/jsx-props-no-spreading */
+import React from 'react';
 import ConstructorIOClient from '@constructor-io/constructorio-client-javascript';
-import CioQuiz from '../../../components/CioQuiz';
+import CioQuiz, { IQuizProps } from '../../../components/CioQuiz';
 import { argTypes } from '../argTypes';
 import { stringifyWithDefaults } from '../../../utils';
 import { ComponentTemplate, addComponentStoryDescription } from '.';
@@ -83,3 +84,15 @@ const cioJsClient = new ConstructorIOClient({ apiKey: '${apiKey}' });
 const args = ${stringifyWithDefaults(ProvideCIOClientInstance.args)};`,
   cioJsClientDescription
 );
+
+function RenderInASmallContainerTemplate(args: IQuizProps) {
+  return (
+    <div className='small-container-example-wrapper'>
+      <div className='small-container-example'>
+        <CioQuiz {...args} />
+      </div>
+    </div>
+  );
+}
+export const RenderInASmallContainer = RenderInASmallContainerTemplate.bind({});
+RenderInASmallContainer.args = { apiKey, quizId, resultsPageOptions };

--- a/src/styles.css
+++ b/src/styles.css
@@ -31,6 +31,7 @@
   --bottom-bar-height: 80px;
   --primary-color: var(--blue-denim-400);
   --container-image-small-height: 250px;
+  container: quiz / inline-size;
 }
 
 /* Mobile + global styles */
@@ -467,7 +468,7 @@
 /* Media Queries */
 
 /* Small Tablet */
-@media screen and (min-width: 640px) {
+@container (min-width: 640px) {
   /* Container */
   .cio-container--with-image {
     display: flex;
@@ -522,12 +523,7 @@
 }
 
 /* Big Tablet */
-@media screen and (min-width: 768px) {
-  /* Quiz */
-  .cio-quiz {
-    font-size: 18px;
-  }
-
+@container (min-width: 768px) {
   /* Container */
   .cio-container {
     align-items: center;
@@ -615,7 +611,7 @@
 }
 
 /* Desktop */
-@media screen and (min-width: 1280px) {
+@container (min-width: 1280px) {
   /* Container */
   .cio-container--with-image {
     padding: 6rem 2rem;

--- a/src/styles.css
+++ b/src/styles.css
@@ -227,14 +227,15 @@
   box-shadow: 0px 4px 10px rgba(93, 124, 232, 0.25);
 }
 .cio-select-question-container {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  align-self: start;
   max-width: 1200px;
-  margin-bottom: var(--bottom-bar-height);
   padding: 1rem;
   margin-top: 2rem;
+  min-height: calc(100% - 3rem); /* Full height - padding - margin */
   width: 100%;
 }
 .cio-question-options-container {
@@ -243,7 +244,7 @@
   flex-wrap: wrap;
   gap: 1rem;
   width: 100%;
-  margin-bottom: auto;
+  margin-bottom: var(--bottom-bar-height);
   margin-top: 2rem;
 }
 .cio-question-options-container-text-only {
@@ -586,6 +587,7 @@
     padding: 1rem 5rem;
   }
   .cio-select-question-container {
+    justify-content: center;
     margin: 0;
     padding: 2rem;
     padding-bottom: 0;

--- a/src/styles.css
+++ b/src/styles.css
@@ -40,8 +40,11 @@
   font-family: 'Inter', sans-serif;
 }
 .cio-quiz {
+  position: relative;
   min-width: 100%;
   min-height: 100%;
+  height: 100%;
+  overflow: auto;
   display: flex;
   justify-content: center;
   background-color: #ffffff;
@@ -128,7 +131,7 @@
   height: var(--bottom-bar-height);
   padding: 8px 16px;
   display: flex;
-  position: fixed;
+  position: absolute;
   bottom: 0px;
   left: 0px;
   background: white;
@@ -465,7 +468,7 @@
 
 /* Small Tablet */
 @media screen and (min-width: 640px) {
-   /* Container */
+  /* Container */
   .cio-container--with-image {
     display: flex;
     justify-content: center;
@@ -535,7 +538,7 @@
     align-items: center;
     flex-direction: row;
   }
-  
+
   /* Input */
   .cio-question-input-text {
     margin-bottom: 1rem;
@@ -543,7 +546,7 @@
 
   /* Image */
   .cio-question-image-container {
-    max-height: 1000px;
+    max-height: 100%;
   }
   .cio-cover-question-container--with-image .cio-question-image-container {
     max-height: unset;
@@ -631,7 +634,6 @@
   .cio-select-question-text {
     padding: 2.5rem 0rem;
   }
-
 
   /* Results component */
   .cio-results-container {


### PR DESCRIPTION
Added
![image](https://github.com/Constructor-io/constructorio-ui-quizzes/assets/2954126/860c34f9-3952-4489-8488-e95b312ece4f)
![image](https://github.com/Constructor-io/constructorio-ui-quizzes/assets/2954126/ef1bc5cb-1a9b-452d-8b50-81aedd3e71d0)

--------------

I had to change the button positioning in the select question a bit to have it play nice with the scroll. I couldn't find a way to make it be sticky to the content while playing nice with the overflow. If you can find a way, please let me know and we can update it