### PR TITLE
[CSL-2439] Adds option to pass instructions to control bar

### DIFF
--- a/src/components/ControlBar/ControlBar.tsx
+++ b/src/components/ControlBar/ControlBar.tsx
@@ -24,7 +24,7 @@ function ControlBar(props: ControlBarProps) {
   return (
     <div className='cio-question-buttons-container'>
       {showBackButton && <BackButton onClick={backButtonHandler} />}
-      {instructions && instructions !== '' ? (
+      {instructions ? (
         <div className='cio-question-buttons-container-text'>{instructions}</div>
       ) : (
         ''

--- a/src/components/ControlBar/ControlBar.tsx
+++ b/src/components/ControlBar/ControlBar.tsx
@@ -24,11 +24,7 @@ function ControlBar(props: ControlBarProps) {
   return (
     <div className='cio-question-buttons-container'>
       {showBackButton && <BackButton onClick={backButtonHandler} />}
-      {instructions ? (
-        <div className='cio-question-buttons-container-text'>{instructions}</div>
-      ) : (
-        ''
-      )}
+      {instructions && <div className='cio-question-buttons-container-text'>{instructions}</div>}
       <CTAButton
         disabled={isNextButtonDisabled}
         ctaText={ctaButtonText}

--- a/src/components/ControlBar/ControlBar.tsx
+++ b/src/components/ControlBar/ControlBar.tsx
@@ -8,6 +8,7 @@ interface ControlBarProps {
   backButtonHandler?: () => void;
   nextButtonHandler: () => void;
   ctaButtonText?: string;
+  instructions?: string;
 }
 
 function ControlBar(props: ControlBarProps) {
@@ -17,11 +18,17 @@ function ControlBar(props: ControlBarProps) {
     ctaButtonText,
     nextButtonHandler,
     isNextButtonDisabled,
+    instructions,
   } = props;
 
   return (
     <div className='cio-question-buttons-container'>
       {showBackButton && <BackButton onClick={backButtonHandler} />}
+      {instructions && instructions !== '' ? (
+        <div className='cio-question-buttons-container-text'>{instructions}</div>
+      ) : (
+        ''
+      )}
       <CTAButton
         disabled={isNextButtonDisabled}
         ctaText={ctaButtonText}

--- a/src/components/SelectTypeQuestion/SelectTypeQuestion.tsx
+++ b/src/components/SelectTypeQuestion/SelectTypeQuestion.tsx
@@ -16,11 +16,22 @@ function SelectTypeQuestion() {
   let question;
   let type: `${QuestionTypes}`;
   let hasImages = false;
+  let instructions;
 
   if (state?.quiz.currentQuestion) {
     question = state.quiz.currentQuestion.next_question;
     type = question.type;
     hasImages = question.options.some((option: QuestionOption) => option.images);
+    switch (type) {
+      case QuestionTypes.MultipleSelect:
+        instructions = 'Select one or more options';
+        break;
+      case QuestionTypes.SingleSelect:
+        instructions = 'Select one option';
+        break;
+      default:
+        instructions = null;
+    }
   }
 
   const [selected, setSelected] = useState<Selected>({});
@@ -109,6 +120,7 @@ function SelectTypeQuestion() {
           backButtonHandler={previousQuestion}
           showBackButton={!state?.quiz.isFirstQuestion}
           ctaButtonText={question?.cta_text}
+          instructions={instructions}
         />
       </div>
     );

--- a/src/components/SelectTypeQuestion/SelectTypeQuestion.tsx
+++ b/src/components/SelectTypeQuestion/SelectTypeQuestion.tsx
@@ -22,16 +22,7 @@ function SelectTypeQuestion() {
     question = state.quiz.currentQuestion.next_question;
     type = question.type;
     hasImages = question.options.some((option: QuestionOption) => option.images);
-    switch (type) {
-      case QuestionTypes.MultipleSelect:
-        instructions = 'Select one or more options';
-        break;
-      case QuestionTypes.SingleSelect:
-        instructions = 'Select one option';
-        break;
-      default:
-        instructions = null;
-    }
+    instructions = type === QuestionTypes.MultipleSelect && 'Select one or more options';
   }
 
   const [selected, setSelected] = useState<Selected>({});

--- a/src/styles.css
+++ b/src/styles.css
@@ -192,6 +192,9 @@
   background-color: rgba(255, 255, 255, 0.87);
   align-items: center;
 }
+.cio-question-buttons-container-text {
+  display: none;
+}
 .cio-question-cta-button {
   background: var(--primary-color);
   color: #ffffff;
@@ -593,6 +596,15 @@
   /* Result Card component */
   .cio-result-card {
     flex-basis: 30%;
+  }
+
+  /* Control Bar Instructions */
+    .cio-question-buttons-container-text {
+    text-align: center;
+    flex-grow: 1;
+    color: var(--gray-dust-100);
+    font-size: 1.125rem;
+    display: block;
   }
 }
 


### PR DESCRIPTION
Adds a descriptor in the control bar for `Select`-type questions:
- Single Select: "Select one option"
- Multi Select: "Select one or more options"

Figured this might be a more common use-case so I made the solution easily extensible (but not more complicated) in case we'd want to add the ability for Question Components to receive such a prop.