### PR TITLE
[CSL-2303] Fixes layout shifts in Open Text and Cover Questions

### DIFF
--- a/src/components/CoverTypeQuestion/CoverTypeQuestion.tsx
+++ b/src/components/CoverTypeQuestion/CoverTypeQuestion.tsx
@@ -29,6 +29,7 @@ export default function CoverTypeQuestion() {
         cio-cover-question-container${hasImage ? '--with-image' : ''}
       `}
         data-question-key={question.key}>
+        {hasImage ? renderImages(question.images, 'cio-question-image-container') : ''}
         <div className='cio-question-content'>
           <QuestionTitle title={question?.title} />
           <QuestionDescription description={question.description} />
@@ -39,7 +40,6 @@ export default function CoverTypeQuestion() {
             ctaButtonText={question?.cta_text}
           />
         </div>
-        {hasImage ? renderImages(question.images, 'cio-question-image-container') : ''}
       </div>
     );
   }

--- a/src/styles.css
+++ b/src/styles.css
@@ -69,7 +69,6 @@
 /* Container */
 .cio-container {
   display: flex;
-  align-items: center;
   justify-content: center;
   margin-top: 2rem;
   padding-bottom: var(--bottom-bar-height);
@@ -129,7 +128,6 @@
 .cio-question-content {
   display: flex;
   flex-direction: column;
-  height: 100%;
   padding: 1rem;
 }
 
@@ -157,6 +155,7 @@
   width: 100%;
   object-fit: cover;
   max-height: var(--container-image-small-height);
+  height: var(--container-image-small-height); /* Fixed height for layout shifts*/
   display: flex;
 }
 
@@ -254,7 +253,6 @@
 
 /* Cover Page Component */
 .cio-cover-question-container--with-image {
-  flex-direction: column-reverse;
   padding: 0;
   padding-bottom: var(--bottom-bar-height);
 }
@@ -606,7 +604,7 @@
   .cio-container--with-image {
     padding: 6% 2%;
     align-items: center;
-    flex-direction: row;
+    flex-direction: row-reverse;
   }
 
   /* Input */


### PR DESCRIPTION
Note changes to:
- Cover-Questions page (mobile) - Fixed height makes the image larger
- Cover-Question HTML Structure
    - I moved the elements around and added the flex-direction: row-reverse on >tablet-sizes since (a) it felt weird, from a mobile-first standpoint, that the image is lower on the html than the content and (b) allows us to apply alignment correctly on flex-column (i.e. on mobile, content aligns to the top by default rather than to the bottom w/ flex-direction: column-reverse)