### PR TITLE
Fix try again button on zero results page

### DIFF
--- a/src/components/ResultContainer/ResultContainer.tsx
+++ b/src/components/ResultContainer/ResultContainer.tsx
@@ -31,7 +31,7 @@ export default function ResultContainer(props: IResultContainerProps) {
             resultCardRegularPriceKey={resultCardRegularPriceKey}
           />
         )}
-        {zeroResults && <ZeroResults />}
+        {zeroResults && resetQuiz && <ZeroResults resetQuizClickHandler={resetQuiz} />}
       </div>
     );
   }

--- a/src/components/ZeroResults/ZeroResults.tsx
+++ b/src/components/ZeroResults/ZeroResults.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import { QuizEventsReturn } from '../../types';
 import CTAButton from '../CTAButton/CTAButton';
 
 interface ZeroResultsProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  resetQuizClickHandler?: () => {};
+  resetQuizClickHandler: QuizEventsReturn.ResetQuiz;
 }
 
 function ZeroResults(props: ZeroResultsProps) {


### PR DESCRIPTION
This is fixed in the [hooks PR](https://github.com/Constructor-io/constructorio-ui-quizzes/pull/76/files#diff-3b8a6bcca4206de32dc0813ce044e6086cb3748e9242d5a741b5058a30c65774R19) as well but did a separate fix here also just in case the hooks PR takes longer