### PR TITLE
[CSL-2693] Add total number of results text to quizzes results page

### DIFF
--- a/src/components/ResultContainer/ResultContainer.tsx
+++ b/src/components/ResultContainer/ResultContainer.tsx
@@ -21,7 +21,8 @@ export default function ResultContainer(props: IResultContainerProps) {
     renderResultCardPriceDetails,
   } = options;
   const { state } = useContext(QuizContext);
-  const zeroResults = !state?.quiz.results?.response?.results?.length;
+  const numberOfResults = state?.quiz.results?.response?.results?.length;
+  const zeroResults = !numberOfResults;
   const resultsTitle = zeroResults ? '' : 'Here are your results';
 
   if (state?.quiz.results) {
@@ -33,13 +34,16 @@ export default function ResultContainer(props: IResultContainerProps) {
           <RedoButton />
         </div>
         {!zeroResults && (
-          <Results
-            resultCardSalePriceKey={resultCardSalePriceKey}
-            resultCardRegularPriceKey={resultCardRegularPriceKey}
-            resultCardRatingCountKey={resultCardRatingCountKey}
-            resultCardRatingScoreKey={resultCardRatingScoreKey}
-            renderResultCardPriceDetails={renderResultCardPriceDetails}
-          />
+          <>
+            <div className='cio-results-num-results'>{numberOfResults} results</div>
+            <Results
+              resultCardSalePriceKey={resultCardSalePriceKey}
+              resultCardRegularPriceKey={resultCardRegularPriceKey}
+              resultCardRatingCountKey={resultCardRatingCountKey}
+              resultCardRatingScoreKey={resultCardRatingScoreKey}
+              renderResultCardPriceDetails={renderResultCardPriceDetails}
+            />
+          </>
         )}
         {zeroResults && <ZeroResults />}
       </div>

--- a/src/components/ResultContainer/ResultContainer.tsx
+++ b/src/components/ResultContainer/ResultContainer.tsx
@@ -35,7 +35,9 @@ export default function ResultContainer(props: IResultContainerProps) {
         </div>
         {!zeroResults && (
           <>
-            <div className='cio-results-num-results'>{numberOfResults} results</div>
+            <div className='cio-results-num-results'>
+              {numberOfResults} {numberOfResults === 1 ? 'result' : 'results'}
+            </div>
             <Results
               resultCardSalePriceKey={resultCardSalePriceKey}
               resultCardRegularPriceKey={resultCardRegularPriceKey}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,6 +22,7 @@ export const componentDescription = `- import \`CioQuiz\` to render in your JSX.
   - \`resultCardRatingCountKey\` is an optional parameter that specifies the metadata field name for the ratings count 
   - \`resultCardRatingScoreKey\` is an optional parameter that specifies the metadata field name for the ratings score 
   - \`renderResultCardPriceDetails\` is an optional render function to render custom prices section in result card 
+  - \`numResultsToDisplay\` is an optional parameter that determines how many results should be displayed on results page
 - \`sessionStateOptions\` lets you configure the session modal behavior
   - \`showSessionModal\` is a boolean used to decide whether to show the session modal. The default behavior is to show the session modal
   - \`showSessionModalOnResults\` is a boolean to decide whether to show the session modal after reaching the results page. The default behavior is to not show the session modal

--- a/src/stories/Quiz/Component/QuizResults/QuizResults.stories.tsx
+++ b/src/stories/Quiz/Component/QuizResults/QuizResults.stories.tsx
@@ -43,6 +43,7 @@ export const QuizResultsPage: Story = {
     const resultsFilterMedium = canvas.getByText('Medium');
     const redoButton = document.querySelector('.cio-question-redo-button');
     const resultCards = document.querySelectorAll('.cio-result-card');
+    const numResults = canvas.getByText('3 results');
 
     expect(resultsTitle).toBeInTheDocument();
     expect(selectedOptions).toBeInTheDocument();
@@ -50,5 +51,6 @@ export const QuizResultsPage: Story = {
     expect(selectedOptions).toContainElement(resultsFilterMedium);
     expect(redoButton).toBeInTheDocument();
     expect(resultCards.length).toEqual(3);
+    expect(numResults).toBeInTheDocument();
   },
 };

--- a/src/stories/Quiz/tests/index.stories.tsx
+++ b/src/stories/Quiz/tests/index.stories.tsx
@@ -140,6 +140,7 @@ e2eInteractionTest.play = async ({ canvasElement }) => {
   // Results page
   await sleep(500);
   expect(await canvas.findByText('Here are your results')).toBeInTheDocument();
+  expect(await canvas.findByText('10 results')).toBeInTheDocument();
   expect(await canvas.findByText('Because you answered')).toBeInTheDocument();
   expect(document.querySelectorAll('.cio-results-filter-option')?.length).toBeGreaterThan(0);
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -434,6 +434,13 @@
   align-items: center;
   font-size: 0.75rem;
 }
+.cio-quiz .cio-results-num-results {
+  margin-top: 2.75rem;
+  font-family: 'Inter', sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  color: var(--gray-dust-500);
+}
 .cio-quiz .cio-results {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
The logic should be min(numResultsToDisplay, totalNumResultsFromResponse)

Actual total num results: 100
Customer override for num results to display: -
Our default: 20
Number that should be shown in UI: 20

Actual total num results: 100
Customer override for num results to display: 40
Our default: 20
Number that should be shown in UI: 40

Actual total num results: 5
Customer override for num results to display: 10
Our default: 20
Number that should be shown in UI: 5

Actual total num results: 5
Customer override for num results to display: -
Our default: 20
Number that should be shown in UI: 5