### PR TITLE
Fix select options without images margin

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -745,7 +745,6 @@
     flex-wrap: wrap;
     justify-content: center;
     margin-bottom: 2rem;
-    margin-top: 0;
   }
   .cio-quiz .cio-question-option-container-text-only {
     margin: 0;


### PR DESCRIPTION
Before and After
<img width="1366" alt="Screenshot 2023-08-17 at 10 07 26 PM" src="https://github.com/Constructor-io/constructorio-ui-quizzes/assets/58053149/234861a9-c3b0-48ca-8021-6f46fdda4843">
<img width="1366" alt="Screenshot 2023-08-17 at 10 07 31 PM" src="https://github.com/Constructor-io/constructorio-ui-quizzes/assets/58053149/f7a3d100-d792-4e05-accf-4b54b91ace62">
