### PR TITLE
[QUIZ-537] Add progress bar for quizzes UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@constructor-io/constructorio-client-javascript": "^2.35.14",
+        "@constructor-io/constructorio-client-javascript": "^2.35.17",
         "react": ">=16.12.0",
         "react-dom": ">=16.12.0",
         "tslib": "^2.4.0"
@@ -2192,9 +2192,9 @@
       }
     },
     "node_modules/@constructor-io/constructorio-client-javascript": {
-      "version": "2.35.14",
-      "resolved": "https://registry.npmjs.org/@constructor-io/constructorio-client-javascript/-/constructorio-client-javascript-2.35.14.tgz",
-      "integrity": "sha512-ZB28OPmLk0ZkmzcVorgjQbAR6jECE09FdCz2K4W+NFX8Tn4dOaj5e2o3t4Psyq2GxpT32bcP9SFO3+0kZ09PGQ==",
+      "version": "2.35.17",
+      "resolved": "https://registry.npmjs.org/@constructor-io/constructorio-client-javascript/-/constructorio-client-javascript-2.35.17.tgz",
+      "integrity": "sha512-cXsj/T2WBi8iEJ9UklZIyiukpWP15hrIWj+ep3o8eqfjNSUvtmq4hafsJxBn1jGex7OO1GN7vOtc43kjDiN+Jg==",
       "peer": true,
       "dependencies": {
         "@constructor-io/constructorio-id": "^2.4.10",
@@ -22376,9 +22376,9 @@
       "optional": true
     },
     "@constructor-io/constructorio-client-javascript": {
-      "version": "2.35.14",
-      "resolved": "https://registry.npmjs.org/@constructor-io/constructorio-client-javascript/-/constructorio-client-javascript-2.35.14.tgz",
-      "integrity": "sha512-ZB28OPmLk0ZkmzcVorgjQbAR6jECE09FdCz2K4W+NFX8Tn4dOaj5e2o3t4Psyq2GxpT32bcP9SFO3+0kZ09PGQ==",
+      "version": "2.35.17",
+      "resolved": "https://registry.npmjs.org/@constructor-io/constructorio-client-javascript/-/constructorio-client-javascript-2.35.17.tgz",
+      "integrity": "sha512-cXsj/T2WBi8iEJ9UklZIyiukpWP15hrIWj+ep3o8eqfjNSUvtmq4hafsJxBn1jGex7OO1GN7vOtc43kjDiN+Jg==",
       "peer": true,
       "requires": {
         "@constructor-io/constructorio-id": "^2.4.10",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "check-license": "license-checker --production --onlyAllow 'Apache-2.0;BSD-3-Clause;MIT;0BSD;BSD-2-Clause' --excludePackages 'picocolors@1.0.0'"
   },
   "peerDependencies": {
-    "@constructor-io/constructorio-client-javascript": "^2.35.14",
+    "@constructor-io/constructorio-client-javascript": "^2.35.17",
     "react": ">=16.12.0",
     "react-dom": ">=16.12.0",
     "tslib": "^2.4.0"

--- a/src/components/CioQuiz/index.tsx
+++ b/src/components/CioQuiz/index.tsx
@@ -101,7 +101,6 @@ export default function CioQuiz(props: IQuizProps) {
             state.quiz.currentQuestion && (
               <>
                 <div className='cio-question-progress-affixed-container'>
-                  Progress{' '}
                   <div className='cio-question-progress-progress-bar'>
                     <div className='cio-question-progress-progress-indicator' />
                   </div>

--- a/src/components/CioQuiz/index.tsx
+++ b/src/components/CioQuiz/index.tsx
@@ -101,10 +101,7 @@ export default function CioQuiz(props: IQuizProps) {
           ) : (
             state.quiz.currentQuestion && (
               <>
-                <ProgressBar
-                  currentQuestionId={state.quiz.currentQuestion.next_question.id}
-                  totalQuestions={state.quiz.currentQuestion.total_questions}
-                />
+                <ProgressBar />
                 <QuizQuestions />
                 <ControlBar ctaButtonText={questionData?.cta_text || undefined} />
               </>

--- a/src/components/CioQuiz/index.tsx
+++ b/src/components/CioQuiz/index.tsx
@@ -100,6 +100,12 @@ export default function CioQuiz(props: IQuizProps) {
           ) : (
             state.quiz.currentQuestion && (
               <>
+                <div className='cio-question-progress-affixed-container'>
+                  Progress{' '}
+                  <div className='cio-question-progress-progress-bar'>
+                    <div className='cio-question-progress-progress-indicator' />
+                  </div>
+                </div>
                 <QuizQuestions />
                 <ControlBar ctaButtonText={questionData?.cta_text || undefined} />
               </>

--- a/src/components/CioQuiz/index.tsx
+++ b/src/components/CioQuiz/index.tsx
@@ -9,6 +9,7 @@ import useQuiz from '../../hooks/useQuiz';
 import SessionPromptModal from '../SessionPromptModal/SessionPromptModal';
 import { IQuizProps } from '../../types';
 import { convertPrimaryColorsToString, renderImages } from '../../utils';
+import ProgressBar from '../ProgressBar/ProgressBar';
 
 export default function CioQuiz(props: IQuizProps) {
   const {
@@ -100,20 +101,10 @@ export default function CioQuiz(props: IQuizProps) {
           ) : (
             state.quiz.currentQuestion && (
               <>
-                <div className='cio-question-progress-affixed-container'>
-                  <div className='cio-question-progress-progress-container'>
-                    <div
-                      className='cio-question-progress-progress-bar'
-                      style={{
-                        width: `${
-                          ((state.quiz.currentQuestion.next_question.id - 1) /
-                            state.quiz.currentQuestion.total_questions) *
-                          100
-                        }%`,
-                      }}
-                    />
-                  </div>
-                </div>
+                <ProgressBar
+                  currentQuestionId={state.quiz.currentQuestion.next_question.id}
+                  totalQuestions={state.quiz.currentQuestion.total_questions}
+                />
                 <QuizQuestions />
                 <ControlBar ctaButtonText={questionData?.cta_text || undefined} />
               </>

--- a/src/components/CioQuiz/index.tsx
+++ b/src/components/CioQuiz/index.tsx
@@ -101,9 +101,9 @@ export default function CioQuiz(props: IQuizProps) {
             state.quiz.currentQuestion && (
               <>
                 <div className='cio-question-progress-affixed-container'>
-                  <div className='cio-question-progress-progress-bar'>
+                  <div className='cio-question-progress-progress-container'>
                     <div
-                      className='cio-question-progress-progress-indicator'
+                      className='cio-question-progress-progress-bar'
                       style={{
                         width: `${
                           ((state.quiz.currentQuestion.next_question.id - 1) /

--- a/src/components/CioQuiz/index.tsx
+++ b/src/components/CioQuiz/index.tsx
@@ -105,7 +105,11 @@ export default function CioQuiz(props: IQuizProps) {
                     <div
                       className='cio-question-progress-progress-indicator'
                       style={{
-                        width: `${((state.quiz.currentQuestion.next_question.id - 1) / 13) * 100}%`,
+                        width: `${
+                          ((state.quiz.currentQuestion.next_question.id - 1) /
+                            state.quiz.currentQuestion.total_questions) *
+                          100
+                        }%`,
                       }}
                     />
                   </div>

--- a/src/components/CioQuiz/index.tsx
+++ b/src/components/CioQuiz/index.tsx
@@ -102,7 +102,12 @@ export default function CioQuiz(props: IQuizProps) {
               <>
                 <div className='cio-question-progress-affixed-container'>
                   <div className='cio-question-progress-progress-bar'>
-                    <div className='cio-question-progress-progress-indicator' />
+                    <div
+                      className='cio-question-progress-progress-indicator'
+                      style={{
+                        width: `${((state.quiz.currentQuestion.next_question.id - 1) / 13) * 100}%`,
+                      }}
+                    />
                   </div>
                 </div>
                 <QuizQuestions />

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -1,21 +1,24 @@
-import React from 'react';
+import React, { useContext } from 'react';
 
-export default function ProgressBar({ totalQuestions, currentQuestionId }: Props) {
+import QuizContext from '../CioQuiz/context';
+
+export default function ProgressBar() {
+  const { state } = useContext(QuizContext);
+  const currentQuestion = state?.quiz.currentQuestion;
+  if (!currentQuestion) return null;
+
   return (
     <div className='cio-question-progress-affixed-container'>
       <div className='cio-question-progress-progress-container'>
         <div
           className='cio-question-progress-progress-bar'
           style={{
-            width: `${((currentQuestionId - 1) / totalQuestions) * 100}%`,
+            width: `${
+              ((currentQuestion.next_question.id - 1) / currentQuestion.total_questions) * 100
+            }%`,
           }}
         />
       </div>
     </div>
   );
 }
-
-type Props = {
-  totalQuestions: number;
-  currentQuestionId: number;
-};

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export default function ProgressBar({ totalQuestions, currentQuestionId }: Props) {
+  return (
+    <div className='cio-question-progress-affixed-container'>
+      <div className='cio-question-progress-progress-container'>
+        <div
+          className='cio-question-progress-progress-bar'
+          style={{
+            width: `${((currentQuestionId - 1) / totalQuestions) * 100}%`,
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+type Props = {
+  totalQuestions: number;
+  currentQuestionId: number;
+};

--- a/src/styles.css
+++ b/src/styles.css
@@ -398,34 +398,31 @@
 /* Affixed progress bar */
 .cio-quiz .cio-question-progress-affixed-container {
   position: fixed;
-  top: 20px;
-  right: 20px;
+  top: 8px;
+  right: 16px;
   z-index: 100;
   display: flex;
   flex-direction: row;
   align-items: center;
   gap: 7px;
   font-size: 0.75rem;
-  background: rgba(68, 68, 68, 0.267);
-  border-radius: 4px;
   padding: 8px;
   color: white;
+  mix-blend-mode: difference;
 }
 
 .cio-quiz .cio-question-progress-progress-bar {
   width: 100px;
-  /* border-color: #505a75; */
   border-color: white;
   height: 6px;
   border-width: 1px;
   border-style: solid;
   background: transparent;
-  mix-blend-mode: difference;
+  border-radius: 4px;
 }
 
 .cio-quiz .cio-question-progress-progress-indicator {
   width: 36%;
-  /* background: #505a75; */
   background: white;
   height: 100%;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -422,7 +422,6 @@
 }
 
 .cio-quiz .cio-question-progress-progress-indicator {
-  width: 36%;
   background: white;
   height: 100%;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -395,6 +395,35 @@
   margin-bottom: -1rem;
 }
 
+/* Affixed progress bar */
+.cio-quiz .cio-question-progress-affixed-container {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  z-index: 100;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 7px;
+  font-size: 0.9rem;
+}
+
+.cio-quiz .cio-question-progress-progress-bar {
+  width: 100px;
+  border-color: #505a75;
+  height: 6px;
+  border-width: 1px;
+  border-style: solid;
+  background: transparent;
+  mix-blend-mode: difference;
+}
+
+.cio-quiz .cio-question-progress-progress-indicator {
+  width: 36%;
+  background: #505a75;
+  height: 100%;
+}
+
 /* Results component */
 .cio-quiz .cio-results-container {
   width: 100%;

--- a/src/styles.css
+++ b/src/styles.css
@@ -405,12 +405,17 @@
   flex-direction: row;
   align-items: center;
   gap: 7px;
-  font-size: 0.9rem;
+  font-size: 0.75rem;
+  background: rgba(68, 68, 68, 0.267);
+  border-radius: 4px;
+  padding: 8px;
+  color: white;
 }
 
 .cio-quiz .cio-question-progress-progress-bar {
   width: 100px;
-  border-color: #505a75;
+  /* border-color: #505a75; */
+  border-color: white;
   height: 6px;
   border-width: 1px;
   border-style: solid;
@@ -420,7 +425,8 @@
 
 .cio-quiz .cio-question-progress-progress-indicator {
   width: 36%;
-  background: #505a75;
+  /* background: #505a75; */
+  background: white;
   height: 100%;
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -410,8 +410,7 @@
   color: white;
   mix-blend-mode: difference;
 }
-
-.cio-quiz .cio-question-progress-progress-bar {
+.cio-quiz .cio-question-progress-progress-container {
   width: 100px;
   border-color: white;
   height: 6px;
@@ -420,8 +419,7 @@
   background: transparent;
   border-radius: 4px;
 }
-
-.cio-quiz .cio-question-progress-progress-indicator {
+.cio-quiz .cio-question-progress-progress-bar {
   background: white;
   height: 100%;
 }


### PR DESCRIPTION
Add affixed progress bar to each quiz question interface. Progress bar uses `mix-blend-mode: difference` to differentiate it from the background irregardless of image brightness.

<img width="1001" alt="CleanShot 2023-08-23 at 13 31 03@2x" src="https://github.com/Constructor-io/constructorio-ui-quizzes/assets/7874219/eece02fe-ae57-46cb-8bcc-3a3b77bb9444">
