### PR TITLE
[CSL-2715] onQuizNextQuestion callback

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,6 +23,8 @@ export const componentDescription = `- import \`CioQuiz\` to render in your JSX.
   - \`resultCardRatingScoreKey\` is an optional parameter that specifies the metadata field name for the ratings score 
   - \`renderResultCardPriceDetails\` is an optional render function to render custom prices section in result card 
   - \`numResultsToDisplay\` is an optional parameter that determines how many results should be displayed on results page
+- \`callbacks\` lets you pass callback functions that will be called on certain actions
+  - \`onQuizNextQuestion\` is an optional callback function that will be called when user moves to the next question
 - \`sessionStateOptions\` lets you configure the session modal behavior
   - \`showSessionModal\` is a boolean used to decide whether to show the session modal. The default behavior is to show the session modal
   - \`showSessionModalOnResults\` is a boolean to decide whether to show the session modal after reaching the results page. The default behavior is to not show the session modal
@@ -90,6 +92,7 @@ In the example below, the \`primaryColor\` prop has been used to override this c
 
 > Advanced Option: Instead of passing a primaryColor prop, you can also override \`--primary-color-h\`, \`--primary-color-s\`, and \`--primary-color-l\` CSS variables within a \`.cio-quiz\` container element. If explicitly given a value in your CSS, then the values of these variables will be used as the HSL values for your quiz.
 `;
+export const callbacksDescription = `Pass an \`apiKey\`, a \`quizId\`, and \`callbacks\``;
 
 export enum RequestStates {
   Stale = 'STALE',

--- a/src/hooks/useQuizEvents/index.ts
+++ b/src/hooks/useQuizEvents/index.ts
@@ -27,7 +27,7 @@ const useQuizEvents: UseQuizEvents = (quizOptions, cioClient, quizState) => {
     quizStateKey,
     quizLocalState,
   } = quizState;
-  const { resultsPageOptions } = quizOptions;
+  const { resultsPageOptions, callbacks } = quizOptions;
 
   const { onAddToCartClick, onQuizResultClick, onQuizResultsLoaded, onAddToFavoritesClick } =
     resultsPageOptions;
@@ -36,7 +36,12 @@ const useQuizEvents: UseQuizEvents = (quizOptions, cioClient, quizState) => {
   const quizAnswerChanged = useQuizAnswerChangeHandler(quizApiState, dispatchLocalState);
 
   // Quiz Next button click callback
-  const nextQuestion = useQuizNextClick(quizApiState, quizLocalState, dispatchLocalState);
+  const nextQuestion = useQuizNextClick(
+    quizApiState,
+    quizLocalState,
+    dispatchLocalState,
+    callbacks?.onQuizNextQuestion
+  );
 
   // Quiz Back button click callback
   const previousQuestion = useQuizBackClick(quizApiState, dispatchLocalState);

--- a/src/hooks/useQuizEvents/useQuizNextClick.ts
+++ b/src/hooks/useQuizEvents/useQuizNextClick.ts
@@ -2,26 +2,39 @@ import { useCallback } from 'react';
 import { ActionAnswerQuestion, QuestionTypes } from '../../components/CioQuiz/actions';
 import { QuizAPIReducerState } from '../../components/CioQuiz/quizApiReducer';
 import { QuizLocalReducerState } from '../../components/CioQuiz/quizLocalReducer';
-import { QuizEventsReturn } from '../../types';
+import { QuizEventsReturn, OnQuizNextQuestion } from '../../types';
+import { isFunction } from '../../utils';
 
 const useQuizNextClick = (
   quizApiState: QuizAPIReducerState,
   quizLocalState: QuizLocalReducerState,
-  dispatchLocalState: React.Dispatch<ActionAnswerQuestion>
+  dispatchLocalState: React.Dispatch<ActionAnswerQuestion>,
+  onQuizNextQuestion?: OnQuizNextQuestion
 ): QuizEventsReturn.NextQuestion => {
   const quizNexClickHandler = useCallback(() => {
     const currentQuestion = quizApiState.quizCurrentQuestion?.next_question;
     const currentQuestionId = currentQuestion?.id;
+
     if (dispatchLocalState && currentQuestionId) {
       const currentAnswerInput = quizLocalState.answerInputs[currentQuestionId];
+
       if (currentAnswerInput?.value?.length || currentQuestion?.type === 'cover') {
         dispatchLocalState({
           type: QuestionTypes.Next,
           payload: quizApiState.quizCurrentQuestion,
         });
       }
+
+      if (currentQuestion && onQuizNextQuestion && isFunction(onQuizNextQuestion)) {
+        onQuizNextQuestion({ ...currentQuestion, answer: currentAnswerInput });
+      }
     }
-  }, [dispatchLocalState, quizApiState.quizCurrentQuestion, quizLocalState.answerInputs]);
+  }, [
+    dispatchLocalState,
+    quizApiState.quizCurrentQuestion,
+    quizLocalState.answerInputs,
+    onQuizNextQuestion,
+  ]);
 
   return quizNexClickHandler;
 };

--- a/src/stories/Quiz/Component/index.stories.tsx
+++ b/src/stories/Quiz/Component/index.stories.tsx
@@ -12,8 +12,9 @@ import {
   smallContainerDescription,
   apiKey,
   quizId,
+  callbacksDescription,
 } from '../../../constants';
-import { IQuizProps } from '../../../types';
+import { IQuizProps, QuestionWithAnswer } from '../../../types';
 
 export default {
   title: 'Quiz/Full Quiz',
@@ -50,8 +51,18 @@ const resultsPageOptions = {
   resultCardSalePriceKey: 'salePrice',
 };
 
+const callbacks = {
+  onQuizNextQuestion: (question: QuestionWithAnswer) => {
+    console.dir(question);
+  },
+};
+
 export const BasicUsage = ComponentTemplate.bind({});
-BasicUsage.args = { apiKey, quizId, resultsPageOptions };
+BasicUsage.args = {
+  apiKey,
+  quizId,
+  resultsPageOptions,
+};
 addComponentStoryDescription(
   BasicUsage,
   `const args = ${stringifyWithDefaults(BasicUsage.args)}`,
@@ -110,4 +121,17 @@ import ConstructorIOClient from '@constructor-io/constructorio-client-javascript
 const cioJsClient = new ConstructorIOClient({ apiKey: '${apiKey}' });
 const args = ${stringifyWithDefaults(ProvideCIOClientInstance.args)};`,
   cioJsClientDescription
+);
+
+export const PassCallbacks = ComponentTemplate.bind({});
+PassCallbacks.args = {
+  apiKey,
+  quizId,
+  resultsPageOptions,
+  callbacks,
+};
+addComponentStoryDescription(
+  PassCallbacks,
+  `const args = ${stringifyWithDefaults(PassCallbacks.args)}`,
+  callbacksDescription
 );

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ import {
   QuizResultsResponse,
   Nullable,
   QuestionOption,
+  Question,
 } from '@constructor-io/constructorio-client-javascript/lib/types';
 import ConstructorIOClient from '@constructor-io/constructorio-client-javascript';
 import { RequestStates } from './constants';
@@ -54,6 +55,16 @@ export interface SessionStateOptions {
   sessionStateKey?: string;
 }
 
+export type QuestionWithAnswer = Question & {
+  answer: AnswerInput;
+};
+
+export type OnQuizNextQuestion = (question: QuestionWithAnswer) => void;
+
+export interface Callbacks {
+  onQuizNextQuestion?: OnQuizNextQuestion;
+}
+
 export interface IQuizProps {
   apiKey?: string;
   cioJsClient?: ConstructorIOClient;
@@ -62,6 +73,7 @@ export interface IQuizProps {
   resultsPageOptions: ResultsPageOptions;
   sessionStateOptions?: SessionStateOptions;
   primaryColor?: string;
+  callbacks?: Callbacks;
 }
 
 // QUIZ RETURN VALUES
@@ -81,11 +93,13 @@ export interface QuizReturnState {
   };
 }
 
+export type AnswerInput = {
+  type: InputQuestionsTypes;
+  value: string | string[];
+};
+
 export type AnswerInputState = {
-  [key: string]: {
-    type: InputQuestionsTypes;
-    value: string | string[];
-  };
+  [key: string]: AnswerInput;
 };
 
 export type InputQuestionsTypes =

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -59,6 +59,7 @@ export const functionStrings = {
   onQuizResultClick: `(result, position) => console.dir(result, position)`,
   onAddToFavoritesClick: `(item) => console.dir(item)`,
   onQuizResultsLoaded: `(results) => console.dir(results)`,
+  onQuizNextQuestion: `(question) => console.dir(question)`,
   cioJsClient: `cioJsClient`,
 };
 


### PR DESCRIPTION
I decided to leave the callbacks under `resultsPageOptions` as is because they are highly tied to results page. I think we can leave them there and add the rest of the callbacks to `callbacks` object. Let me know if you think otherwise, open to suggestions