### PR TITLE
Add support for favoriteItems array

### DIFF
--- a/src/hooks/usePropsGetters/index.ts
+++ b/src/hooks/usePropsGetters/index.ts
@@ -28,7 +28,8 @@ import useAddToFavoritesButtonProps from './useAddToFavoritesButtonProps';
 const usePropsGetters = (
   quizEvents: QuizEventsReturn,
   quizApiState: QuizAPIReducerState,
-  quizLocalState: QuizLocalReducerState
+  quizLocalState: QuizLocalReducerState,
+  favoriteItems?: string[]
 ) => {
   const {
     quizAnswerChanged,
@@ -96,8 +97,10 @@ const usePropsGetters = (
     [addToCart]
   );
 
-  const getAddToFavoritesButtonProps: GetAddToFavoritesButtonProps =
-    useAddToFavoritesButtonProps(addToFavorites);
+  const getAddToFavoritesButtonProps: GetAddToFavoritesButtonProps = useAddToFavoritesButtonProps(
+    addToFavorites,
+    favoriteItems
+  );
 
   const quizResultClickDown = useCallback(
     (event: KeyboardEvent<HTMLElement>, result: Partial<QuizResultData>, position: number) => {

--- a/src/hooks/usePropsGetters/useAddToFavoritesButtonProps.ts
+++ b/src/hooks/usePropsGetters/useAddToFavoritesButtonProps.ts
@@ -1,9 +1,11 @@
 import { useState, useCallback } from 'react';
+import { QuizResultData } from '@constructor-io/constructorio-client-javascript/lib/types';
 import { GetAddToFavoritesButtonProps, QuizEventsReturn } from '../../types';
 import { Favorited } from '../../components/ResultFavoritesButton/ResultFavoritesButton';
 
 export default function useAddToFavoritesButtonProps(
-  addToFavorites: QuizEventsReturn.AddToFavorites
+  addToFavorites: QuizEventsReturn.AddToFavorites,
+  favoriteItems?: string[]
 ): GetAddToFavoritesButtonProps {
   const [favorited, setFavorited] = useState<Favorited>({});
 
@@ -14,13 +16,16 @@ export default function useAddToFavoritesButtonProps(
     [favorited]
   );
 
+  const isResultFavorited = (result: Partial<QuizResultData>) =>
+    result?.data?.id && favoriteItems?.includes(result?.data?.id);
+
   const getAddToFavoritesButtonProps: GetAddToFavoritesButtonProps = useCallback(
     (result, price) => ({
       className: `${'cio-result-card-favorites-button'} ${
-        favorited?.[result?.data?.id || '0'] ? 'favorited' : ''
+        result?.data?.id && favoriteItems?.includes(result?.data?.id) ? 'favorited' : ''
       }`,
       onClick: (e) => {
-        addToFavorites(e, result, price, !favorited?.[result?.data?.id || '0']);
+        addToFavorites(e, result, price, !isResultFavorited(result));
         toggleIdFavorited(result?.data?.id || '0');
       },
       type: 'button',

--- a/src/hooks/useQuiz.ts
+++ b/src/hooks/useQuiz.ts
@@ -8,7 +8,12 @@ import useQuizEvents from './useQuizEvents';
 import useQuizState from './useQuizState';
 
 const useQuiz: UseQuiz = (quizOptions) => {
-  const { apiKey, cioJsClient, primaryColor } = quizOptions;
+  const {
+    apiKey,
+    cioJsClient,
+    primaryColor,
+    resultsPageOptions: { favoriteItems },
+  } = quizOptions;
 
   // Log console errors for required parameters quizId and resultsPageOptions
   useConsoleErrors(quizOptions);
@@ -25,7 +30,7 @@ const useQuiz: UseQuiz = (quizOptions) => {
   // Props getters
   const { quizApiState, quizLocalState, quizSessionStorageState } = quizState;
   const { skipToResults } = quizSessionStorageState;
-  const propGetters = usePropsGetters(quizEvents, quizApiState, quizLocalState);
+  const propGetters = usePropsGetters(quizEvents, quizApiState, quizLocalState, favoriteItems);
 
   const primaryColorStyles = usePrimaryColorStyles(primaryColor);
 

--- a/src/stories/Quiz/Component/index.stories.tsx
+++ b/src/stories/Quiz/Component/index.stories.tsx
@@ -49,6 +49,7 @@ const resultsPageOptions = {
   },
   resultCardRegularPriceKey: 'price',
   resultCardSalePriceKey: 'salePrice',
+  favoriteItems: ['119010868', '119011085'],
 };
 
 const callbacks = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,7 @@ export namespace QuizResultsEventsProps {
 
 export interface ResultsPageOptions extends ResultCardProps {
   numResultsToDisplay?: number;
+  favoriteItems?: string[];
   onQuizResultsLoaded?: QuizResultsEventsProps.OnQuizResultsLoaded;
   onQuizResultClick?: QuizResultsEventsProps.OnQuizResultClick;
   onAddToCartClick: QuizResultsEventsProps.OnAddToCartClick;


### PR DESCRIPTION
Consumers of the library will need to provide `favoriteItems` array of Ids to handle favorites rendering state and whether to send conversion events or not.