### PR TITLE
Quiz docs formatting

### DIFF
--- a/src/stories/Quiz/argTypes.ts
+++ b/src/stories/Quiz/argTypes.ts
@@ -12,15 +12,75 @@ export const argTypes = {
   apiKey: {
     description: 'Your Constructor API key. Either `apiKey` or `cioJsClient` are required',
   },
-  callbacks: {
-    description: `Callback functions to be called when events are fired
-    \`onQuizNextQuestion?: (question) => void);\`
-    \`onQuizResultsLoaded?: (results) => void;\`
-    \`onQuizResultClick?: (result, position: number) => void;\`
-    \`onAddToCartClick?: (result) => void;\`
-    \`onAddToFavoritesClick?: (result) => void;\`
-    `,
+  onQuizNextQuestion: {
+    description: 'Callback function to be called when the next question is loaded',
     control: false,
+    table: {
+      subcategory: 'callbacks',
+      defaultValue: {
+        summary: 'null',
+      },
+      type: {
+        summary: '(question) => void',
+        detail: '(question: QuestionWithAnswer) => void',
+      },
+    },
+  },
+  onQuizResultsLoaded: {
+    description: 'Callback function to be called when the quiz results are loaded',
+    control: false,
+    table: {
+      subcategory: 'callbacks',
+      defaultValue: {
+        summary: 'null',
+      },
+      type: {
+        summary: '(results) => void',
+        detail: '(results: QuizResultDataPartial) => void',
+      },
+    },
+  },
+  onQuizResultClick: {
+    description: 'Callback function to be called when a quiz result is clicked',
+    control: false,
+    table: {
+      subcategory: 'callbacks',
+      defaultValue: {
+        summary: 'null',
+      },
+      type: {
+        summary: '(result, position: number) => void',
+        detail: '(result: QuizResultDataPartial, position: number) => void',
+      },
+    },
+  },
+  onAddToCartClick: {
+    description: 'Callback function to be called when the add to cart button is clicked',
+    control: false,
+    table: {
+      subcategory: 'callbacks',
+      defaultValue: {
+        summary: 'null',
+      },
+      type: {
+        summary: '(result) => void',
+        detail: '(result: QuizResultDataPartial) => void',
+      },
+    },
+  },
+  onAddToFavoritesClick: {
+    description: 'Callback function to be called when the add to favorites button is clicked',
+    control: false,
+    table: {
+      subcategory: 'callbacks',
+      defaultValue: {
+        summary: 'null',
+      },
+      type: {
+        summary: '(result) => void',
+        detail: '(result: QuizResultDataPartial) => void',
+      },
+    },
   },
   cioJsClient: {
     description:
@@ -42,15 +102,140 @@ export const argTypes = {
      \n And \`renderResultCardPriceDetails: (result) => JSX.Element\` a render result card price details callback function
     `,
   },
-  resultsPageOptions: {
-    description: 'Results page configuration options `numResultsToDisplay: number`',
+  resultCardRegularPriceKey: {
+    description: 'Key name for the regular price in the API response',
+    control: {
+      type: 'text',
+    },
+    table: {
+      subcategory: 'resultCardOptions',
+      defaultValue: {
+        summary: 'regular_price',
+      },
+      type: {
+        summary: 'string',
+      },
+    },
   },
-  sessionStateOptions: {
-    description: `Session Storage state configuration options
-    \`showSessionModal?: boolean;\` (Whether to show modal to hydrate quiz on quiz results page)
-    \`showSessionModalOnResults?: boolean;\`(Whether to show modal to hydrate quiz)
-    \`sessionStateKey?: string;\`(key name where session storage state is saved)
-    `,
+  resultCardSalePriceKey: {
+    description: 'Key name for the sale price in the API response',
+    control: {
+      type: 'text',
+    },
+    table: {
+      subcategory: 'resultCardOptions',
+      defaultValue: {
+        summary: 'sale_price',
+      },
+      type: {
+        summary: 'string',
+      },
+    },
+  },
+  resultCardRatingCountKey: {
+    description: 'Key name for the rating count in the API response',
+    control: {
+      type: 'text',
+    },
+    table: {
+      subcategory: 'resultCardOptions',
+      defaultValue: {
+        summary: 'rating_count',
+      },
+      type: {
+        summary: 'string',
+      },
+    },
+  },
+  resultCardRatingScoreKey: {
+    description: 'Key name for the rating score in the API response',
+    control: {
+      type: 'text',
+    },
+    table: {
+      subcategory: 'resultCardOptions',
+      defaultValue: {
+        summary: 'rating_score',
+      },
+      type: {
+        summary: 'string',
+      },
+    },
+  },
+  renderResultCardPriceDetails: {
+    description: 'Callback function to render result card price details',
+    control: false,
+    table: {
+      subcategory: 'resultCardOptions',
+      defaultValue: {
+        summary: 'null',
+      },
+      type: {
+        summary: '(result) => JSX.Element',
+        detail: '(result: QuizResultDataPartial) => JSX.Element',
+      },
+    },
+  },
+  numResultsToDisplay: {
+    description: 'Number of results to display on the results page',
+    control: {
+      type: 'number',
+    },
+    table: {
+      subcategory: 'resultsPageOptions',
+      defaultValue: {
+        summary: 5,
+      },
+      type: {
+        summary: 'number',
+      },
+    },
+  },
+  showSessionModal: {
+    description:
+      'Boolean for whether or not to show session modal to hydrate quiz on the results page',
+    control: {
+      type: 'boolean',
+    },
+    table: {
+      subcategory: 'sessionStateOptions',
+      defaultValue: {
+        summary: false,
+      },
+      type: {
+        summary: 'boolean',
+      },
+    },
+  },
+  showSessionModalOnResults: {
+    description: 'Boolean for whether or not to show session modal to hydrate quiz',
+    control: {
+      type: 'boolean',
+    },
+    table: {
+      subcategory: 'sessionStateOptions',
+      defaultValue: {
+        summary: false,
+      },
+      type: {
+        summary: 'boolean',
+      },
+    },
+  },
+  sessionStateKey: {
+    description: 'Key name where session storage state is saved',
+    control: {
+      type: 'text',
+    },
+    table: {
+      subcategory: 'sessionStateOptions',
+      defaultValue: {
+        summary: 'quizState',
+      },
+      type: {
+        summary: 'string',
+      },
+    },
   },
   enableHydration: {
     description: 'Boolean for whether or not to hydrate quiz questions and results on page reload',

--- a/src/stories/Quiz/argTypes.ts
+++ b/src/stories/Quiz/argTypes.ts
@@ -92,16 +92,6 @@ export const argTypes = {
       type: 'text',
     },
   },
-  resultCardOptions: {
-    description: `Result card configuration options
-      (Required for the component interface and has to match the keys in the API response to be correctly rendered)
-      \n\`resultCardRegularPriceKey: string\`
-      \`resultCardSalePriceKey: string\` 
-      \`resultCardRatingCountKey: string\`
-      \`resultCardRatingScoreKey: string\` 
-     \n And \`renderResultCardPriceDetails: (result) => JSX.Element\` a render result card price details callback function
-    `,
-  },
   resultCardRegularPriceKey: {
     description: 'Key name for the regular price in the API response',
     control: {


### PR DESCRIPTION
Noticed that the layout we had in place could get a bit confusing and hard to read (screenshot 1). Was messing around with the settings and doing it this way makes it a little more easy to follow (screenshot 2), though I don't know how things would get wired up. 

I'm also not sure if this would actually work since the original options are still there even though it was removed from the `argTypes` object (screenshot 3).


Found this interesting GitHub thread as well in dealing with nested options. Looks like things can get quite complex real fast 😅 : https://github.com/storybookjs/storybook/issues/16089

It also looks like someone built an add-on that we might be able to use as well: https://www.npmjs.com/package/storybook-addon-deep-controls

**_Please note that I've only done very brief research on the topic._**

![Screenshot 2023-09-27 at 1 18 23 PM](https://github.com/Constructor-io/constructorio-ui-quizzes/assets/7194266/2468756e-adc0-440f-b41f-867f15b8da6a)

![Screenshot 2023-09-27 at 2 08 40 PM](https://github.com/Constructor-io/constructorio-ui-quizzes/assets/7194266/8818d0de-25ba-49f7-a6c6-9baaa379fbe1)

![Screenshot 2023-09-27 at 2 12 33 PM](https://github.com/Constructor-io/constructorio-ui-quizzes/assets/7194266/97d3586b-2416-4141-bb59-a29753da14e7)