### PR TITLE
[CSL-3139] Fix styles in useQuiz live example

### DIFF
--- a/src/stories/Quiz/Hooks/index.tsx
+++ b/src/stories/Quiz/Hooks/index.tsx
@@ -108,18 +108,19 @@ export default function HooksTemplate(args) {
                   </div>
                 ))}
             </div>
-
-            {zeroResults && (
-              <div className='cio-zero-results'>
-                <h3 className='cio-zero-results-subtitle'>
-                  Sorry, we couldn’t find products that perfectly match your preferences.
-                </h3>
-                <div className='cio-button-container'>
-                  <button {...getResetQuizButtonProps()}>Try Again</button>
-                </div>
-              </div>
-            )}
           </div>
+
+          {/* Control Bar */}
+          {zeroResults && (
+            <div className='cio-zero-results'>
+              <h3 className='cio-zero-results-subtitle'>
+                Sorry, we couldn’t find products that perfectly match your preferences.
+              </h3>
+              <div className='cio-button-container'>
+                <button {...getResetQuizButtonProps()}>Try Again</button>
+              </div>
+            </div>
+          )}
         </div>
       );
     }
@@ -142,12 +143,18 @@ export default function HooksTemplate(args) {
                 <h1 className='cio-question-title'>{currentQuestionData.title}</h1>
                 <p className='cio-question-description'>{currentQuestionData.description}</p>
                 <input {...getOpenTextInputProps()} />
-                <div className='cio-question-buttons-container'>
-                  <button {...getPreviousQuestionButtonProps()}>Back</button>
-                  <div className='cio-button-container'>
-                    <button {...getSkipQuestionButtonProps()}>Skip</button>
-                    <button {...getNextQuestionButtonProps()}>Continue</button>
-                  </div>
+              </div>
+            </div>
+
+            {/* Control Bar */}
+            <div className='cio-question-buttons-container'>
+              <button {...getPreviousQuestionButtonProps()}>Back</button>
+              <div className='cio-question-buttons-group'>
+                <div className='cio-button-container'>
+                  <button {...getSkipQuestionButtonProps()}>Skip</button>
+                </div>
+                <div className='cio-button-container'>
+                  <button {...getNextQuestionButtonProps()}>Continue</button>
                 </div>
               </div>
             </div>
@@ -168,12 +175,18 @@ export default function HooksTemplate(args) {
               <div className='cio-question-content'>
                 <h1 className='cio-question-title'>{currentQuestionData.title}</h1>
                 <p className='cio-question-description'>{currentQuestionData.description}</p>
-                <div className='cio-question-buttons-container'>
-                  <button {...getPreviousQuestionButtonProps()}>Back</button>
-                  <div className='cio-button-container'>
-                    <button {...getSkipQuestionButtonProps()}>Skip</button>
-                    <button {...getNextQuestionButtonProps()}>Continue</button>
-                  </div>
+              </div>
+            </div>
+
+            {/* Control Bar */}
+            <div className='cio-question-buttons-container'>
+              <button {...getPreviousQuestionButtonProps()}>Back</button>
+              <div className='cio-question-buttons-group'>
+                <div className='cio-button-container'>
+                  <button {...getSkipQuestionButtonProps()}>Skip</button>
+                </div>
+                <div className='cio-button-container'>
+                  <button {...getNextQuestionButtonProps()}>Continue</button>
                 </div>
               </div>
             </div>
@@ -198,11 +211,16 @@ export default function HooksTemplate(args) {
                   </div>
                 ))}
               </div>
+            </div>
 
-              <div className='cio-question-buttons-container'>
-                <button {...getPreviousQuestionButtonProps()}>Back</button>
+            {/* Control Bar */}
+            <div className='cio-question-buttons-container'>
+              <button {...getPreviousQuestionButtonProps()}>Back</button>
+              <div className='cio-question-buttons-group'>
                 <div className='cio-button-container'>
                   <button {...getSkipQuestionButtonProps()}>Skip</button>
+                </div>
+                <div className='cio-button-container'>
                   <button {...getNextQuestionButtonProps()}>Continue</button>
                 </div>
               </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -236,6 +236,7 @@
   flex-grow: 1;
   margin-left: auto;
   width: 100%;
+  transition: background 0.2s ease-in-out;
 }
 .cio-quiz .cio-button-container {
   max-width: 10rem;
@@ -297,12 +298,14 @@
   /* Rather than setting a prefix-ed width, we add padding to allow different contents to fit nicely */
   /* 1.2rem padding + arrow ~= 48px */
   padding: 0 1.2rem;
+  outline: 1px solid transparent;
+  transition: outline 0.2s ease-in-out;
 }
 .cio-quiz .cio-question-back-button:hover {
-  border: 2px solid var(--primary-color-variant-600);
+  outline: 1px solid var(--primary-color-variant-600);
 }
 .cio-quiz .cio-question-back-button:active {
-  border: 2px solid var(--primary-color-variant-700);
+  border: 1px solid var(--primary-color-variant-700);
 }
 .cio-quiz .cio-question-back-button:focus {
   outline: 3px solid var(--primary-color-variant-100);

--- a/src/styles.css
+++ b/src/styles.css
@@ -292,9 +292,11 @@
   border: 1px solid var(--primary-color);
   border-radius: 4px;
   height: 3rem;
-  width: 3rem;
   font-size: 1rem;
   margin-right: 4rem;
+  /* Rather than setting a prefix-ed width, we add padding to allow different contents to fit nicely */
+  /* 1.2rem padding + arrow ~= 48px */
+  padding: 0 1.2rem;
 }
 .cio-quiz .cio-question-back-button:hover {
   border: 2px solid var(--primary-color-variant-600);


### PR DESCRIPTION
Styles weren't working in the Hooks Live Example not because of CSS but because we started using a new css class `cio-question-buttons-group` in the Components, which was missing in the example.

I also moved the "Control Bar" to be a top level .cio-quiz child to emulate our current style of having the control bar fill the whole container and be fixed to the bottom.