### PR TITLE
[CSL-3026] Replace example index key with demo API Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ import CioQuiz from '@constructor-io/constructorio-ui-quizzes';
 function YourComponent() {
   return (
     <div>
-      <CioQuiz quizId='coffee-quiz' apiKey='key_wJSdZSiesX5hiVLt' />
+      <CioQuiz quizId='coffee-quiz' apiKey='key_n4SkMH5PFWLdStQZ' />
     </div>
   );
 }
@@ -48,7 +48,7 @@ import CioQuiz from '@constructor-io/constructorio-ui-quizzes/constructorio-ui-q
 CioQuiz({
   selector: '#quiz-container',
   quizId: 'coffee-quiz',
-  apiKey: 'key_wJSdZSiesX5hiVLt',
+  apiKey: 'key_n4SkMH5PFWLdStQZ',
   includeCSS: true, // Include the default CSS styles. Defaults to true.
   resultCardOptions: {
     resultCardRegularPriceKey: 'price',

--- a/cspell.json
+++ b/cspell.json
@@ -6,7 +6,7 @@
   "ignorePaths": ["lib", "docs"],
   "flagWords": [],
   "words": [
-    "key_wJSdZSiesX5hiVLt",
+    "key_n4SkMH5PFWLdStQZ",
     "constructorio",
     "Combobox",
     "searchandizing",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 // Autocomplete key index
-export const apiKey = 'key_wJSdZSiesX5hiVLt';
+export const apiKey = 'key_n4SkMH5PFWLdStQZ';
 export const quizId = 'coffee-quiz';
 
 // Session Storage default key

--- a/src/stories/Quiz/Component/Usage Examples.mdx
+++ b/src/stories/Quiz/Component/Usage Examples.mdx
@@ -15,7 +15,7 @@ import '@constructor-io/constructorio-ui-quizzes/styles.css';
 export function YourComponent() {
   const quizArgs = {
     quizId: 'coffee-quiz',
-    apiKey: 'key_wJSdZSiesX5hiVLt',
+    apiKey: 'key_n4SkMH5PFWLdStQZ',
     resultCardOptions: {
       resultCardRegularPriceKey: 'price',
     },
@@ -39,7 +39,7 @@ import ConstructorIOClient from '@constructor-io/constructorio-client-javascript
 import CioQuiz from '@constructor-io/constructorio-ui-quizzes';
 import '@constructor-io/constructorio-ui-quizzes/styles.css';
 
-const cioJsClient = new ConstructorIOClient({ apiKey: 'key_wJSdZSiesX5hiVLt' });
+const cioJsClient = new ConstructorIOClient({ apiKey: 'key_n4SkMH5PFWLdStQZ' });
 
 export function YourComponent() {
   const quizArgs = {
@@ -68,7 +68,7 @@ import '@constructor-io/constructorio-ui-quizzes/styles.css';
 export function YourComponent() {
   const quizArgs = {
     quizId: 'coffee-quiz',
-    apiKey: 'key_wJSdZSiesX5hiVLt',
+    apiKey: 'key_n4SkMH5PFWLdStQZ',
     resultCardOptions: {
       resultCardRegularPriceKey: 'price',
     },
@@ -116,7 +116,7 @@ import '@constructor-io/constructorio-ui-quizzes/styles.css';
 export function YourComponent() {
   const quizArgs = {
     quizId: 'coffee-quiz',
-    apiKey: 'key_wJSdZSiesX5hiVLt',
+    apiKey: 'key_n4SkMH5PFWLdStQZ',
     primaryColor: "255, 82, 48"
   };
 


### PR DESCRIPTION
Moves the Storybook examples to use the demo index instead. I didn't copy over behavioral learnings since it didn't seem necessary but lmk if I should and I can ask DS to trigger it.