### PR TITLE
Handle answers required for createQuizUrl function

### DIFF
--- a/src/hooks/useQuizState/useQuizApiState.ts
+++ b/src/hooks/useQuizState/useQuizApiState.ts
@@ -111,7 +111,7 @@ const useQuizApiState: UseQuizApiState = (
         await dispatchSharedQuizResults();
       } else if (skipToResults && quizLocalState.answers.length) {
         await dispatchQuizResults();
-      } else {
+      } else if (!skipToResults) {
         try {
           const quizVersionId = quizLocalState.quizVersionId || quizVersionIdProp;
           const { quizSessionId } = quizLocalState;

--- a/src/hooks/useQuizState/useQuizApiState.ts
+++ b/src/hooks/useQuizState/useQuizApiState.ts
@@ -40,30 +40,28 @@ const useQuizApiState: UseQuizApiState = (
   const { quizId, quizVersionId: quizVersionIdProp, resultsPageOptions } = quizOptions;
   const { queryItems, queryAttributes, isSharedResultsQuery } = useQueryParams();
   const dispatchQuizResults = async () => {
-    if (quizLocalState.answers.length) {
-      try {
-        const quizResults = await getQuizResults(cioClient, quizId, {
-          answers: quizLocalState.answers,
-          resultsPerPage: resultsPageOptions?.numResultsToDisplay,
-          quizVersionId: quizLocalState.quizVersionId,
-          quizSessionId: quizLocalState.quizSessionId,
+    try {
+      const quizResults = await getQuizResults(cioClient, quizId, {
+        answers: quizLocalState.answers,
+        resultsPerPage: resultsPageOptions?.numResultsToDisplay,
+        quizVersionId: quizLocalState.quizVersionId,
+        quizSessionId: quizLocalState.quizSessionId,
+      });
+      // Set quiz results state
+      dispatchApiState({
+        type: QuizAPIActionTypes.SET_QUIZ_RESULTS,
+        payload: {
+          quizResults,
+        },
+      });
+      if (!quizLocalState.isQuizCompleted)
+        dispatchLocalState({
+          type: QuestionTypes.Complete,
         });
-        // Set quiz results state
-        dispatchApiState({
-          type: QuizAPIActionTypes.SET_QUIZ_RESULTS,
-          payload: {
-            quizResults,
-          },
-        });
-        if (!quizLocalState.isQuizCompleted)
-          dispatchLocalState({
-            type: QuestionTypes.Complete,
-          });
-      } catch (error) {
-        dispatchApiState({
-          type: QuizAPIActionTypes.SET_IS_ERROR,
-        });
-      }
+    } catch (error) {
+      dispatchApiState({
+        type: QuizAPIActionTypes.SET_IS_ERROR,
+      });
     }
   };
 
@@ -111,7 +109,7 @@ const useQuizApiState: UseQuizApiState = (
       });
       if (isSharedResultsQuery) {
         await dispatchSharedQuizResults();
-      } else if (skipToResults) {
+      } else if (skipToResults && quizLocalState.answers.length) {
         await dispatchQuizResults();
       } else {
         try {

--- a/src/hooks/useQuizState/useQuizApiState.ts
+++ b/src/hooks/useQuizState/useQuizApiState.ts
@@ -40,28 +40,30 @@ const useQuizApiState: UseQuizApiState = (
   const { quizId, quizVersionId: quizVersionIdProp, resultsPageOptions } = quizOptions;
   const { queryItems, queryAttributes, isSharedResultsQuery } = useQueryParams();
   const dispatchQuizResults = async () => {
-    try {
-      const quizResults = await getQuizResults(cioClient, quizId, {
-        answers: quizLocalState.answers,
-        resultsPerPage: resultsPageOptions?.numResultsToDisplay,
-        quizVersionId: quizLocalState.quizVersionId,
-        quizSessionId: quizLocalState.quizSessionId,
-      });
-      // Set quiz results state
-      dispatchApiState({
-        type: QuizAPIActionTypes.SET_QUIZ_RESULTS,
-        payload: {
-          quizResults,
-        },
-      });
-      if (!quizLocalState.isQuizCompleted)
-        dispatchLocalState({
-          type: QuestionTypes.Complete,
+    if (quizLocalState.answers.length) {
+      try {
+        const quizResults = await getQuizResults(cioClient, quizId, {
+          answers: quizLocalState.answers,
+          resultsPerPage: resultsPageOptions?.numResultsToDisplay,
+          quizVersionId: quizLocalState.quizVersionId,
+          quizSessionId: quizLocalState.quizSessionId,
         });
-    } catch (error) {
-      dispatchApiState({
-        type: QuizAPIActionTypes.SET_IS_ERROR,
-      });
+        // Set quiz results state
+        dispatchApiState({
+          type: QuizAPIActionTypes.SET_QUIZ_RESULTS,
+          payload: {
+            quizResults,
+          },
+        });
+        if (!quizLocalState.isQuizCompleted)
+          dispatchLocalState({
+            type: QuestionTypes.Complete,
+          });
+      } catch (error) {
+        dispatchApiState({
+          type: QuizAPIActionTypes.SET_IS_ERROR,
+        });
+      }
     }
   };
 


### PR DESCRIPTION
This PR only wraps a code block with an if condition.

`dispatchQuizResults` was throwing an error when answers is an empty array (initially)

Added a condition to only getQuizResults when answers isn't empty.