### PR TITLE
[CI-2336] Run TSC check as a Github Action

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "scripts": {
     "storybook-docs-dev": "storybook dev --docs -p 6007",
     "lint": "eslint src --ext js,ts,jsx,tsx",
-    "check-types": "npx tsc --noEmit",
+    "check-types": "tsc -p tsconfig-mjs.json --noEmit && tsc -p tsconfig-cjs.json --noEmit",
     "copy-styles": "cp src/styles.css lib/styles.css",
     "prepare": "husky install",
     "dev": "storybook dev -p 6006",


### PR DESCRIPTION
We were already running `tsc` but it wasn't using our specific tsconfig files. I updated the command to use the same ones in the `compile` command