### PR TITLE
fix getQuizResultLinkProps type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -49,7 +49,7 @@ export interface ResultCardOptions {
     getters: {
       getAddToCartButtonProps?: GetAddToCartButtonProps;
       getAddToFavoritesButtonProps?: GetAddToFavoritesButtonProps;
-      getResultLinkProps?: GetQuizResultLinkProps;
+      getQuizResultLinkProps?: GetQuizResultLinkProps;
     },
     index: number
   ) => JSX.Element;


### PR DESCRIPTION
There is a typo for the name of the prop getResultLinkProps