### PR TITLE
Fix quiz hydration bug when the quizId gets updated

### DIFF
--- a/src/hooks/useQuizEvents/useHydrateQuizLocalState.ts
+++ b/src/hooks/useQuizEvents/useHydrateQuizLocalState.ts
@@ -23,7 +23,7 @@ const useHydrateQuizLocalState = (
   useEffect(() => {
     if (skipToResults) hydrateQuizLocalStateHandler();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [quizId]);
 
   return hydrateQuizLocalStateHandler;
 };


### PR DESCRIPTION
There's a bug with the hydration logic if the quizId prop is being updated via state.

- To reproduce the bug add this to `RenderInASmallContainerTemplate`

 
```
const [quizIdState, setQuizIdState] = useState('');

  useEffect(() => {
    setQuizIdState('coffee-quiz');
 }, []);

```

- Then pass quizId={quizIdState} to <CioQuiz /> in `RenderInASmallContainerTemplate`
- Take the quiz to the end
- Reload the page the quiz disappears and won't be rendered even after reloading

The reason is that the hydrate quiz logic is skipped

