### PR TITLE
Fix deploy-storybook github workflow

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -44,10 +44,10 @@ jobs:
         uses: actions/configure-pages@v2
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: './docs'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
**Problem Statement**:

**The GitHub workflow responsible for deploying to Storybook failed**:

- Reason is GitHub [deprecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) artifact actions
- While we don't use them directly, we use `upload-pages-artifact` which internally reference them
- `upload-pages-artifact` updated the deprecated artifacts on this version 
   -  [v3.0.0](https://github.com/actions/upload-pages-artifact/releases/tag/v3.0.0)
- [The error](https://github.com/Constructor-io/constructorio-ui-autocomplete/actions/runs/13138775496/job/36661093955)


**Definition of done**

- Use `upload-pages-artifact@v3` This version is using the v4 artifact actions
- Use `deploy-pages@v4` since it's required with `upload-pages-artifact@v3`