### PR TITLE
Support getResultCardImage url for a custom image url

### DIFF
--- a/spec/components/ResultCard/ResultCard.server.test.tsx
+++ b/spec/components/ResultCard/ResultCard.server.test.tsx
@@ -15,6 +15,7 @@ describe(`${ResultCard.name} client`, () => {
     ratingCountKey: 'rating_count',
     ratingScoreKey: 'rating_score',
     renderResultCardPriceDetails: jest.fn().mockReturnValue(<div>Price Details</div>),
+    getResultCardImageUrl: jest.fn().mockReturnValue('www.custom_img.com'),
   };
 
   const contextMocks: Partial<QuizContextValue> = {
@@ -36,6 +37,11 @@ describe(`${ResultCard.name} client`, () => {
     it('renders custom price details', () => {
       const view = renderToString(<Subject {...props} />);
       expect(view).toContain('Price Details');
+    });
+
+    it('renders custom image url', () => {
+      const view = renderToString(<Subject {...props} />);
+      expect(view).toContain('www.custom_img.com');
     });
 
     it('calls default price details', () => {

--- a/spec/components/ResultCard/ResultCard.test.tsx
+++ b/spec/components/ResultCard/ResultCard.test.tsx
@@ -15,6 +15,7 @@ describe(`${ResultCard.name} client`, () => {
     ratingCountKey: 'rating_count',
     ratingScoreKey: 'rating_score',
     renderResultCardPriceDetails: jest.fn().mockReturnValue(<div>Price Details</div>),
+    getResultCardImageUrl: jest.fn().mockReturnValue('www.custom_img.com'),
   };
 
   const contextMocks: Partial<QuizContextValue> = {
@@ -58,6 +59,11 @@ describe(`${ResultCard.name} client`, () => {
     it('does not render fav button', () => {
       render(<Subject {...props} />);
       expect(screen.queryByLabelText('Add to favorites')).not.toBeInTheDocument();
+    });
+
+    it('renders custom image url', () => {
+      render(<Subject {...props} />);
+      expect(screen.getByRole('img').getAttribute('src')).toEqual('www.custom_img.com');
     });
   });
 

--- a/src/components/ResultCard/ResultCard.tsx
+++ b/src/components/ResultCard/ResultCard.tsx
@@ -13,7 +13,7 @@ interface ResultCardOptions {
   ratingScoreKey?: string;
   resultPosition: number;
   renderResultCardPriceDetails?: (result: QuizResultDataPartial) => JSX.Element;
-  getResultCardImageUrl?: (imageUrl: string) => string;
+  getResultCardImageUrl?: (result: QuizResultDataPartial) => string;
 }
 
 export default function ResultCard(props: ResultCardOptions) {
@@ -51,11 +51,7 @@ export default function ResultCard(props: ResultCardOptions) {
     <>
       <div className='cio-result-card-image'>
         <img
-          src={
-            getResultCardImageUrl
-              ? getResultCardImageUrl(result.data?.image_url)
-              : result.data?.image_url
-          }
+          src={getResultCardImageUrl ? getResultCardImageUrl(result) : result.data?.image_url}
           alt='product'
         />
       </div>

--- a/src/components/ResultCard/ResultCard.tsx
+++ b/src/components/ResultCard/ResultCard.tsx
@@ -13,6 +13,7 @@ interface ResultCardOptions {
   ratingScoreKey?: string;
   resultPosition: number;
   renderResultCardPriceDetails?: (result: QuizResultDataPartial) => JSX.Element;
+  getResultCardImageUrl?: (imageUrl: string) => string;
 }
 
 export default function ResultCard(props: ResultCardOptions) {
@@ -24,6 +25,7 @@ export default function ResultCard(props: ResultCardOptions) {
     ratingCountKey,
     ratingScoreKey,
     renderResultCardPriceDetails,
+    getResultCardImageUrl,
   } = props;
   const {
     customAddToFavoritesCallback,
@@ -48,7 +50,14 @@ export default function ResultCard(props: ResultCardOptions) {
   const resultCardContent = () => (
     <>
       <div className='cio-result-card-image'>
-        <img src={result.data?.image_url} alt='product' />
+        <img
+          src={
+            getResultCardImageUrl
+              ? getResultCardImageUrl(result.data?.image_url)
+              : result.data?.image_url
+          }
+          alt='product'
+        />
       </div>
       <div className='cio-result-card-text'>
         <p className='cio-result-card-title'>{result.value}</p>

--- a/src/components/Results/Results.tsx
+++ b/src/components/Results/Results.tsx
@@ -13,6 +13,7 @@ function Results(props: ResultsProps) {
     resultCardRatingScoreKey,
     renderResultCardPriceDetails,
     renderResultCard,
+    getResultCardImageUrl,
   } = props;
 
   const { state, getAddToCartButtonProps, getAddToFavoritesButtonProps, getQuizResultLinkProps } =
@@ -32,6 +33,7 @@ function Results(props: ResultsProps) {
             ratingCountKey={resultCardRatingCountKey}
             ratingScoreKey={resultCardRatingScoreKey}
             renderResultCardPriceDetails={renderResultCardPriceDetails}
+            getResultCardImageUrl={getResultCardImageUrl}
             resultPosition={index + 1}
           />
         )

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,7 @@ export interface ResultCardOptions {
     },
     index: number
   ) => JSX.Element;
+  getResultCardImageUrl?: (imageUrl: string) => string;
 }
 
 export namespace QuizResultsEventsProps {

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,7 +53,7 @@ export interface ResultCardOptions {
     },
     index: number
   ) => JSX.Element;
-  getResultCardImageUrl?: (imageUrl: string) => string;
+  getResultCardImageUrl?: (result: QuizResultDataPartial) => string;
 }
 
 export namespace QuizResultsEventsProps {


### PR DESCRIPTION
Support passing a custom image url for result card

This will allow customers to tweak their image urls to add `width` and `height` queries for example to their images to support different image sizes 