### PR TITLE
Replace individual usernames with team in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Define which individuals or teams that are responsible for code in a repository
 
-* @HHHindawy @TarekAlQaddy
+* @Constructor-io/integrations-ui-lib-quizzes-admins


### PR DESCRIPTION
## Summary
- Replace individual GitHub usernames with `@Constructor-io/integrations-ui-lib-quizzes-admins` team in CODEOWNERS

## Related
- [CDX-322](https://linear.app/constructor/issue/CDX-322/update-codeowners)