### PR TITLE
At 100/quiz option description websitejs libraryui library

### DIFF
--- a/spec/hooks/usePropsGetters/useSelectInputProps/useSelectInputProps.test.tsx
+++ b/spec/hooks/usePropsGetters/useSelectInputProps/useSelectInputProps.test.tsx
@@ -32,10 +32,10 @@ describe('Testing Hook (client): useSelectInputProps', () => {
     const { result } = setupHook(currentQuestionData);
 
     act(() => {
-      result.current(currentQuestionData.options[0]).onClick(mockEvent);
+      result.current.getSelectInputProps(currentQuestionData.options[0]).onClick(mockEvent);
     });
 
-    expect(result.current(currentQuestionData.options[0]).className).toContain('selected');
+    expect(result.current.getSelectInputProps(currentQuestionData.options[0]).className).toContain('selected');
     expect(quizAnswerChangedMock).toHaveBeenCalledWith([{ id: '1', value: 'Option 1' }]);
   });
 
@@ -44,10 +44,10 @@ describe('Testing Hook (client): useSelectInputProps', () => {
     const { result } = setupHook(currentQuestionData);
 
     act(() => {
-      result.current(currentQuestionData.options[0]).onClick(mockEvent);
+      result.current.getSelectInputProps(currentQuestionData.options[0]).onClick(mockEvent);
     });
 
-    expect(result.current(currentQuestionData.options[0]).className).toContain('selected');
+    expect(result.current.getSelectInputProps(currentQuestionData.options[0]).className).toContain('selected');
     expect(quizAnswerChangedMock).toHaveBeenCalledWith([{ id: '1', value: 'Option 1' }]);
   });
 
@@ -62,8 +62,8 @@ describe('Testing Hook (client): useSelectInputProps', () => {
     );
 
     act(() => {
-      result
-        .current({ id: 2, value: 'Option 2', attribute: null })
+      result.current
+        .getSelectInputProps({ id: 2, value: 'Option 2', attribute: null })
         .onKeyDown({ key: 'Enter' } as React.KeyboardEvent<HTMLElement>);
     });
 
@@ -95,9 +95,9 @@ describe('Testing Hook (client): useSelectInputProps', () => {
     );
 
     act(() => {
-      result.current(currentQuestionData.options[0]).onClick(mockEvent);
+      result.current.getSelectInputProps(currentQuestionData.options[0]).onClick(mockEvent);
     });
-    expect(result.current(currentQuestionData.options[0]).className).toContain('selected');
+    expect(result.current.getSelectInputProps(currentQuestionData.options[0]).className).toContain('selected');
     expect(nextQuestionMock).not.toHaveBeenCalled();
   });
 
@@ -106,14 +106,14 @@ describe('Testing Hook (client): useSelectInputProps', () => {
     const { result } = setupHook(currentQuestionData);
 
     act(() => {
-      result.current(currentQuestionData.options[0]).onClick(mockEvent);
+      result.current.getSelectInputProps(currentQuestionData.options[0]).onClick(mockEvent);
     });
 
     act(() => {
-      result.current(currentQuestionData.options[0]).onClick(mockEvent);
+      result.current.getSelectInputProps(currentQuestionData.options[0]).onClick(mockEvent);
     });
 
-    expect(result.current(currentQuestionData.options[0]).className).not.toContain('selected');
+    expect(result.current.getSelectInputProps(currentQuestionData.options[0]).className).not.toContain('selected');
     expect(quizAnswerChangedMock).toHaveBeenCalledWith([]);
   });
 
@@ -122,14 +122,14 @@ describe('Testing Hook (client): useSelectInputProps', () => {
     const { result } = setupHook(currentQuestionData);
 
     act(() => {
-      result.current(currentQuestionData.options[0]).onClick(mockEvent);
+      result.current.getSelectInputProps(currentQuestionData.options[0]).onClick(mockEvent);
     });
 
     act(() => {
-      result.current(currentQuestionData.options[0]).onClick(mockEvent);
+      result.current.getSelectInputProps(currentQuestionData.options[0]).onClick(mockEvent);
     });
 
-    expect(result.current(currentQuestionData.options[0]).className).not.toContain('selected');
+    expect(result.current.getSelectInputProps(currentQuestionData.options[0]).className).not.toContain('selected');
     expect(quizAnswerChangedMock).toHaveBeenCalledWith([]);
   });
 });

--- a/spec/hooks/usePropsGetters/useSelectInputProps/useSelectInputProps.test.tsx
+++ b/spec/hooks/usePropsGetters/useSelectInputProps/useSelectInputProps.test.tsx
@@ -101,6 +101,49 @@ describe('Testing Hook (client): useSelectInputProps', () => {
     expect(nextQuestionMock).not.toHaveBeenCalled();
   });
 
+  it('does not advance to the next question for single select when selected option has a description', () => {
+    currentQuestionData.type = 'single';
+    currentQuestionData.options[0] = {
+      ...currentQuestionData.options[0],
+      description: 'Additional details',
+    };
+    const { result } = renderHook(() =>
+      useSelectInputProps(
+        quizAnswerChangedMock,
+        nextQuestionMock,
+        currentQuestionData,
+        answerInputs,
+        true
+      )
+    );
+    act(() => {
+      result.current.getSelectInputProps(currentQuestionData.options[0]).onClick(mockEvent);
+    });
+    expect(result.current.getSelectInputProps(currentQuestionData.options[0]).className).toContain('selected');
+    expect(nextQuestionMock).not.toHaveBeenCalled();
+  });
+
+  it('advances to the next question for single select when selected option does not have a description', () => {
+    currentQuestionData.type = 'single';
+    let inputs = {};
+    const { result, rerender } = renderHook(() =>
+      useSelectInputProps(
+        quizAnswerChangedMock,
+        nextQuestionMock,
+        currentQuestionData,
+        inputs,
+        true
+      )
+    );
+    act(() => {
+      result.current.getSelectInputProps(currentQuestionData.options[0]).onClick(mockEvent);
+    });
+    expect(result.current.getSelectInputProps(currentQuestionData.options[0]).className).toContain('selected');
+    inputs = { 1: { value: [{ id: '1', value: 'Option 1' }] } };
+    rerender();
+    expect(nextQuestionMock).toHaveBeenCalled();
+  });
+
   it('allows toggling options off in a multiple select question', () => {
     currentQuestionData.type = 'multiple';
     const { result } = setupHook(currentQuestionData);

--- a/spec/utils/utils.test.ts
+++ b/spec/utils/utils.test.ts
@@ -14,6 +14,7 @@ import {
   getDisplayedDescription,
 } from '../../src/utils';
 import { QuestionTypes } from '../../src/components/CioQuiz/actions';
+import { Question } from '../../src/types';
 
 describe('convertPrimaryColorsToString', () => {
   it('returns empty string when no images are provided', () => {
@@ -288,8 +289,11 @@ describe('resetQuizSessionStorageState', () => {
 });
 
 describe('getDisplayedDescription', () => {
-  const makeQuestion = (type: string, description?: string, options?: any[]) =>
-    ({ type, description, options } as any);
+  const makeQuestion = (
+    type: string,
+    description?: string,
+    options?: { id: number | string; value: string; description?: string }[]
+  ) => ({ type, description, options } as unknown as Question);
 
   it('returns undefined when question is null or undefined', () => {
     expect(getDisplayedDescription(null, {})).toBeUndefined();

--- a/spec/utils/utils.test.ts
+++ b/spec/utils/utils.test.ts
@@ -11,6 +11,7 @@ import {
   getStateFromSessionStorage,
   isFunction,
   convertPrimaryColorsToString,
+  getDisplayedDescription,
 } from '../../src/utils';
 import { QuestionTypes } from '../../src/components/CioQuiz/actions';
 
@@ -283,5 +284,63 @@ describe('resetQuizSessionStorageState', () => {
       'quizState',
       JSON.stringify({ ...mockData, QUIZ_ID_1: null })
     );
+  });
+});
+
+describe('getDisplayedDescription', () => {
+  const makeQuestion = (type: string, description?: string, options?: any[]) =>
+    ({ type, description, options } as any);
+
+  it('returns undefined when question is null or undefined', () => {
+    expect(getDisplayedDescription(null, {})).toBeUndefined();
+    expect(getDisplayedDescription(undefined, {})).toBeUndefined();
+  });
+
+  it('returns undefined when question has no description and no options', () => {
+    const question = makeQuestion(QuestionTypes.SingleSelect, undefined, undefined);
+    expect(getDisplayedDescription(question, {})).toBeUndefined();
+  });
+
+  it('returns question description for non-single question types', () => {
+    const question = makeQuestion(QuestionTypes.MultipleSelect, 'Question desc', [
+      { id: 1, value: 'A', description: 'Option desc' },
+    ]);
+    expect(getDisplayedDescription(question, { 1: true })).toBe('Question desc');
+  });
+
+  it('returns question description when no option is selected (single select)', () => {
+    const question = makeQuestion(QuestionTypes.SingleSelect, 'Question desc', [
+      { id: 1, value: 'A', description: 'Option desc' },
+    ]);
+    expect(getDisplayedDescription(question, {})).toBe('Question desc');
+  });
+
+  it('returns selected option description when one option is selected (single select)', () => {
+    const question = makeQuestion(QuestionTypes.SingleSelect, 'Question desc', [
+      { id: 1, value: 'A', description: 'Option desc' },
+      { id: 2, value: 'B', description: 'Other desc' },
+    ]);
+    expect(getDisplayedDescription(question, { 1: true })).toBe('Option desc');
+  });
+
+  it('returns question description when selected option has no description (single select)', () => {
+    const question = makeQuestion(QuestionTypes.SingleSelect, 'Question desc', [
+      { id: 1, value: 'A' },
+    ]);
+    expect(getDisplayedDescription(question, { 1: true })).toBe('Question desc');
+  });
+
+  it('returns selected option description for single filter value type', () => {
+    const question = makeQuestion(QuestionTypes.SingleFilterValue, 'Question desc', [
+      { id: 1, value: 'A', description: 'Filter option desc' },
+    ]);
+    expect(getDisplayedDescription(question, { 1: true })).toBe('Filter option desc');
+  });
+
+  it('returns question description when selected option has no description (single filter value)', () => {
+    const question = makeQuestion(QuestionTypes.SingleFilterValue, 'Question desc', [
+      { id: 1, value: 'A' },
+    ]);
+    expect(getDisplayedDescription(question, { 1: true })).toBe('Question desc');
   });
 });

--- a/src/components/CioQuiz/context.ts
+++ b/src/components/CioQuiz/context.ts
@@ -18,8 +18,8 @@ import {
   QuizReturnState,
   GetShareResultsButtonProps,
   GetJumpToQuestionButtonProps,
+  Selected,
 } from '../../types';
-import { Selected } from '../SelectTypeQuestion/SelectTypeQuestion';
 
 export interface QuizContextValue {
   cioClient?: ConstructorIOClient;

--- a/src/components/CioQuiz/context.ts
+++ b/src/components/CioQuiz/context.ts
@@ -19,6 +19,7 @@ import {
   GetShareResultsButtonProps,
   GetJumpToQuestionButtonProps,
 } from '../../types';
+import { Selected } from '../SelectTypeQuestion/SelectTypeQuestion';
 
 export interface QuizContextValue {
   cioClient?: ConstructorIOClient;
@@ -38,6 +39,7 @@ export interface QuizContextValue {
   getQuizResultButtonProps: GetQuizResultButtonProps;
   getQuizResultLinkProps: GetQuizResultLinkProps;
   getJumpToQuestionButtonProps: GetJumpToQuestionButtonProps;
+  selectQuestionSelectedOptions: Selected;
   primaryColorStyles: PrimaryColorStyles;
   customClickItemCallback: boolean;
   customAddToFavoritesCallback: boolean;

--- a/src/components/CioQuiz/index.tsx
+++ b/src/components/CioQuiz/index.tsx
@@ -33,6 +33,7 @@ export default function CioQuiz(props: IQuizProps) {
     getQuizResultLinkProps,
     getResetQuizButtonProps,
     getSelectInputProps,
+    selectQuestionSelectedOptions,
     primaryColorStyles,
     getShareResultsButtonProps,
   } = useQuiz(props);
@@ -80,6 +81,7 @@ export default function CioQuiz(props: IQuizProps) {
     getResetQuizButtonProps,
     getShareResultsButtonProps,
     getSelectInputProps,
+    selectQuestionSelectedOptions,
     customClickItemCallback: !!callbacks?.onQuizResultClick,
     customAddToFavoritesCallback: !!callbacks?.onAddToFavoritesClick,
     primaryColorStyles,

--- a/src/components/SelectTypeQuestion/SelectTypeQuestion.tsx
+++ b/src/components/SelectTypeQuestion/SelectTypeQuestion.tsx
@@ -10,7 +10,11 @@ import { QuestionTypes } from '../CioQuiz/actions';
 export type { Selected };
 
 function SelectTypeQuestion() {
-  const { state, getSelectInputProps, selectQuestionSelectedOptions = {} } = useContext(QuizContext);
+  const {
+    state,
+    getSelectInputProps,
+    selectQuestionSelectedOptions = {},
+  } = useContext(QuizContext);
   let question: Nullable<Question> | undefined;
   let hasImages = false;
   let instructions;
@@ -24,10 +28,7 @@ function SelectTypeQuestion() {
       'Select one or more options';
   }
 
-  const displayedDescription = getDisplayedDescription(
-    question,
-    selectQuestionSelectedOptions
-  );
+  const displayedDescription = getDisplayedDescription(question, selectQuestionSelectedOptions);
 
   if (question) {
     return (

--- a/src/components/SelectTypeQuestion/SelectTypeQuestion.tsx
+++ b/src/components/SelectTypeQuestion/SelectTypeQuestion.tsx
@@ -3,13 +3,11 @@ import { Nullable } from '@constructor-io/constructorio-client-javascript/lib/ty
 import QuestionTitle from '../QuestionTitle/QuestionTitle';
 import QuestionDescription from '../QuestionDescription/QuestionDescription';
 import QuizContext from '../CioQuiz/context';
-import { Question, QuestionOption } from '../../types';
+import { Question, QuestionOption, Selected } from '../../types';
 import { getDisplayedDescription, renderImages } from '../../utils';
 import { QuestionTypes } from '../CioQuiz/actions';
 
-export interface Selected {
-  [key: number]: boolean;
-}
+export type { Selected };
 
 function SelectTypeQuestion() {
   const { state, getSelectInputProps, selectQuestionSelectedOptions } = useContext(QuizContext);

--- a/src/components/SelectTypeQuestion/SelectTypeQuestion.tsx
+++ b/src/components/SelectTypeQuestion/SelectTypeQuestion.tsx
@@ -4,7 +4,7 @@ import QuestionTitle from '../QuestionTitle/QuestionTitle';
 import QuestionDescription from '../QuestionDescription/QuestionDescription';
 import QuizContext from '../CioQuiz/context';
 import { Question, QuestionOption } from '../../types';
-import { renderImages } from '../../utils';
+import { getDisplayedDescription, renderImages } from '../../utils';
 import { QuestionTypes } from '../CioQuiz/actions';
 
 export interface Selected {
@@ -12,7 +12,7 @@ export interface Selected {
 }
 
 function SelectTypeQuestion() {
-  const { state, getSelectInputProps } = useContext(QuizContext);
+  const { state, getSelectInputProps, selectQuestionSelectedOptions } = useContext(QuizContext);
   let question: Nullable<Question> | undefined;
   let hasImages = false;
   let instructions;
@@ -26,6 +26,11 @@ function SelectTypeQuestion() {
       'Select one or more options';
   }
 
+  const displayedDescription = getDisplayedDescription(
+    question,
+    selectQuestionSelectedOptions || {}
+  );
+
   if (question) {
     return (
       <div
@@ -34,7 +39,7 @@ function SelectTypeQuestion() {
         data-question-key={question.key}>
         <div className='cio-select-question-text'>
           <QuestionTitle title={question.title} />
-          {question?.description ? <QuestionDescription description={question.description} /> : ''}
+          {displayedDescription ? <QuestionDescription description={displayedDescription} /> : ''}
         </div>
         {instructions && <div className='cio-select-question-instructions'>{instructions}</div>}
         <div

--- a/src/components/SelectTypeQuestion/SelectTypeQuestion.tsx
+++ b/src/components/SelectTypeQuestion/SelectTypeQuestion.tsx
@@ -10,7 +10,7 @@ import { QuestionTypes } from '../CioQuiz/actions';
 export type { Selected };
 
 function SelectTypeQuestion() {
-  const { state, getSelectInputProps, selectQuestionSelectedOptions } = useContext(QuizContext);
+  const { state, getSelectInputProps, selectQuestionSelectedOptions = {} } = useContext(QuizContext);
   let question: Nullable<Question> | undefined;
   let hasImages = false;
   let instructions;
@@ -26,7 +26,7 @@ function SelectTypeQuestion() {
 
   const displayedDescription = getDisplayedDescription(
     question,
-    selectQuestionSelectedOptions || {}
+    selectQuestionSelectedOptions
   );
 
   if (question) {

--- a/src/components/SelectTypeQuestion/SelectTypeQuestion.tsx
+++ b/src/components/SelectTypeQuestion/SelectTypeQuestion.tsx
@@ -7,8 +7,6 @@ import { Question, QuestionOption, Selected } from '../../types';
 import { getDisplayedDescription, renderImages } from '../../utils';
 import { QuestionTypes } from '../CioQuiz/actions';
 
-export type { Selected };
-
 function SelectTypeQuestion() {
   const {
     state,

--- a/src/components/SelectTypeQuestion/SelectTypeQuestion.tsx
+++ b/src/components/SelectTypeQuestion/SelectTypeQuestion.tsx
@@ -3,7 +3,7 @@ import { Nullable } from '@constructor-io/constructorio-client-javascript/lib/ty
 import QuestionTitle from '../QuestionTitle/QuestionTitle';
 import QuestionDescription from '../QuestionDescription/QuestionDescription';
 import QuizContext from '../CioQuiz/context';
-import { Question, QuestionOption, Selected } from '../../types';
+import { Question, QuestionOption } from '../../types';
 import { getDisplayedDescription, renderImages } from '../../utils';
 import { QuestionTypes } from '../CioQuiz/actions';
 

--- a/src/hooks/usePropsGetters/index.ts
+++ b/src/hooks/usePropsGetters/index.ts
@@ -7,7 +7,6 @@ import {
   GetOpenTextInputProps,
   GetPreviousQuestionButtonProps,
   GetQuizImageProps,
-  GetSelectInputProps,
   QuizEventsReturn,
   GetHydrateQuizButtonProps,
   GetAddToCartButtonProps,

--- a/src/hooks/usePropsGetters/index.ts
+++ b/src/hooks/usePropsGetters/index.ts
@@ -69,7 +69,7 @@ const usePropsGetters = ({
     quizApiState.quizCurrentQuestion?.next_question
   );
 
-  const getSelectInputProps: GetSelectInputProps = useSelectInputProps(
+  const { getSelectInputProps, selected: selectQuestionSelectedOptions } = useSelectInputProps(
     quizAnswerChanged,
     nextQuestion,
     quizApiState.quizCurrentQuestion?.next_question,
@@ -191,6 +191,7 @@ const usePropsGetters = ({
     getQuizImageProps,
     getSelectQuestionImageProps,
     getSelectInputProps,
+    selectQuestionSelectedOptions,
     getCoverQuestionProps,
     getResetQuizButtonProps,
     getShareResultsButtonProps,

--- a/src/hooks/usePropsGetters/useSelectInputProps.ts
+++ b/src/hooks/usePropsGetters/useSelectInputProps.ts
@@ -80,7 +80,7 @@ export default function useSelectInputProps(
       currentQuestionData?.type === QuestionTypes.SingleSelect
     ) {
       const selectedAnswers = currentQuestionData?.options
-        ?.filter((opt) => selected[Number(opt.id)])
+        ?.filter((opt) => selected[opt.id])
         ?.map((opt) => ({ id: opt.id, value: opt.value }));
 
       quizAnswerChanged(selectedAnswers);
@@ -91,7 +91,7 @@ export default function useSelectInputProps(
       currentQuestionData?.type === QuestionTypes.SingleFilterValue
     ) {
       const selectedAnswers = currentQuestionData?.options
-        ?.filter((opt) => selected[String(opt.id)])
+        ?.filter((opt) => selected[opt.id])
         ?.map((opt) => ({
           id: opt.id,
           value: opt.value,

--- a/src/hooks/usePropsGetters/useSelectInputProps.ts
+++ b/src/hooks/usePropsGetters/useSelectInputProps.ts
@@ -17,7 +17,7 @@ export default function useSelectInputProps(
   currentQuestionData?: Nullable<Question>,
   answerInputs?: AnswerInputState,
   nextQuestionOnSingleSelect = true
-): GetSelectInputProps {
+): { getSelectInputProps: GetSelectInputProps; selected: Selected } {
   const type: `${QuestionTypes}` | undefined = currentQuestionData?.type;
   const hasImages = currentQuestionData?.options?.some((option: QuestionOption) => option.images);
 
@@ -116,7 +116,12 @@ export default function useSelectInputProps(
       singleSelectClicked.current &&
       nextQuestionOnSingleSelect
     ) {
-      nextQuestion();
+      const selectedOption = (currentQuestionData?.options as QuestionOption[] | undefined)?.find(
+        (opt) => selected[opt.id]
+      );
+      if (!selectedOption?.description) {
+        nextQuestion();
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [answerInputs]);
@@ -140,5 +145,5 @@ export default function useSelectInputProps(
     [currentQuestionData?.id, selected]
   );
 
-  return getSelectInputProps;
+  return { getSelectInputProps, selected };
 }

--- a/src/hooks/usePropsGetters/useSelectInputProps.ts
+++ b/src/hooks/usePropsGetters/useSelectInputProps.ts
@@ -1,13 +1,13 @@
 import { Nullable } from '@constructor-io/constructorio-client-javascript/lib/types';
 import { useState, useCallback, useEffect, KeyboardEvent, useRef } from 'react';
 import { QuestionTypes } from '../../components/CioQuiz/actions';
-import { Selected } from '../../components/SelectTypeQuestion/SelectTypeQuestion';
 import {
   AnswerInputState,
   GetSelectInputProps,
   Question,
   QuestionOption,
   QuizEventsReturn,
+  Selected,
 } from '../../types';
 
 // eslint-disable-next-line max-params

--- a/src/hooks/usePropsGetters/useSelectInputProps.ts
+++ b/src/hooks/usePropsGetters/useSelectInputProps.ts
@@ -28,17 +28,17 @@ export default function useSelectInputProps(
     (id: number | string) => {
       if (type === QuestionTypes.SingleSelect || type === QuestionTypes.SingleFilterValue) {
         singleSelectClicked.current = true;
-        setSelected({ [id]: true });
+        setSelected({ [String(id)]: true });
         return;
       }
 
       if (type === QuestionTypes.MultipleSelect || type === QuestionTypes.MultipleFilterValues) {
-        if (selected[id]) {
+        if (selected[String(id)]) {
           const newState = { ...selected };
-          delete newState[id];
+          delete newState[String(id)];
           setSelected(newState);
         } else {
-          setSelected({ ...selected, [id]: true });
+          setSelected({ ...selected, [String(id)]: true });
         }
       }
     },
@@ -80,7 +80,7 @@ export default function useSelectInputProps(
       currentQuestionData?.type === QuestionTypes.SingleSelect
     ) {
       const selectedAnswers = currentQuestionData?.options
-        ?.filter((opt) => selected[opt.id])
+        ?.filter((opt) => selected[String(opt.id)])
         ?.map((opt) => ({ id: opt.id, value: opt.value }));
 
       quizAnswerChanged(selectedAnswers);
@@ -91,7 +91,7 @@ export default function useSelectInputProps(
       currentQuestionData?.type === QuestionTypes.SingleFilterValue
     ) {
       const selectedAnswers = currentQuestionData?.options
-        ?.filter((opt) => selected[opt.id])
+        ?.filter((opt) => selected[String(opt.id)])
         ?.map((opt) => ({
           id: opt.id,
           value: opt.value,
@@ -117,7 +117,7 @@ export default function useSelectInputProps(
       nextQuestionOnSingleSelect
     ) {
       const selectedOption = (currentQuestionData?.options as QuestionOption[] | undefined)?.find(
-        (opt) => selected[opt.id]
+        (opt) => selected[String(opt.id)]
       );
       if (!selectedOption?.description) {
         nextQuestion();
@@ -130,7 +130,7 @@ export default function useSelectInputProps(
     (option: QuestionOption) => ({
       className: `${
         !hasImages ? 'cio-question-option-container-text-only' : 'cio-question-option-container'
-      } ${selected[option.id] ? 'selected' : ''}`,
+      } ${selected[String(option.id)] ? 'selected' : ''}`,
       onClick: () => {
         toggleIdSelected(option.id);
       },

--- a/src/hooks/usePropsGetters/useSelectInputProps.ts
+++ b/src/hooks/usePropsGetters/useSelectInputProps.ts
@@ -22,7 +22,7 @@ export default function useSelectInputProps(
   const hasImages = currentQuestionData?.options?.some((option: QuestionOption) => option.images);
 
   const [selected, setSelected] = useState<Selected>({});
-  const singleSelectClicked = useRef({});
+  const singleSelectClicked = useRef(false);
 
   const toggleIdSelected = useCallback(
     (id: number | string) => {

--- a/src/stories/Quiz/Component/QuestionTypes/SingleSelectQuestion.stories.tsx
+++ b/src/stories/Quiz/Component/QuestionTypes/SingleSelectQuestion.stories.tsx
@@ -8,6 +8,7 @@ import {
   getMockQuestionWithImage,
   questionOptionsWithImages,
   questionOptions,
+  questionOptionsWithDescriptions,
 } from '../../tests/mocks';
 import QuestionTypeVariationsDecorator, {
   QuestionTypePrimaryDecorator,
@@ -20,6 +21,10 @@ const singleSelectQuestionWithImages = {
 const singleSelectQuestionWithoutImages = {
   ...getMockQuestion(QuestionTypes.SingleSelect),
   options: questionOptions,
+};
+const singleSelectQuestionWithDescriptions = {
+  ...getMockQuestion(QuestionTypes.SingleSelect),
+  options: questionOptionsWithDescriptions,
 };
 
 const meta: Meta<typeof SelectTypeQuestion> = {
@@ -49,5 +54,12 @@ export const WithoutImages: Story = {
   decorators: [
     (story) =>
       QuestionTypeVariationsDecorator(story, [singleSelectQuestionWithoutImages as SelectQuestion]),
+  ],
+};
+
+export const WithOptionDescriptions: Story = {
+  decorators: [
+    (story) =>
+      QuestionTypePrimaryDecorator(story, [singleSelectQuestionWithDescriptions as SelectQuestion]),
   ],
 };

--- a/src/stories/Quiz/tests/mocks.tsx
+++ b/src/stories/Quiz/tests/mocks.tsx
@@ -84,7 +84,8 @@ export const questionOptions = [
 export const questionOptionsWithDescriptions = [
   {
     ...getMockOption(0, 'coffee'),
-    description: 'A rich, bold beverage made from roasted coffee beans. Perfect for morning energy.',
+    description:
+      'A rich, bold beverage made from roasted coffee beans. Perfect for morning energy.',
   },
   {
     ...getMockOption(1, 'tea'),

--- a/src/stories/Quiz/tests/mocks.tsx
+++ b/src/stories/Quiz/tests/mocks.tsx
@@ -81,6 +81,21 @@ export const questionOptions = [
   },
 ];
 
+export const questionOptionsWithDescriptions = [
+  {
+    ...getMockOption(0, 'coffee'),
+    description: 'A rich, bold beverage made from roasted coffee beans. Perfect for morning energy.',
+  },
+  {
+    ...getMockOption(1, 'tea'),
+    description: 'A soothing warm drink with a variety of flavors. Great for relaxation.',
+  },
+  {
+    ...getMockOption(2, 'water'),
+    description: 'Pure and refreshing hydration. The healthiest choice for any time of day.',
+  },
+];
+
 export const getMockState = (question?: Question, options?: MockOptions): QuizReturnState => ({
   answers: {
     inputs: {
@@ -221,7 +236,7 @@ export const useMockContextValue = (
 
   const getCoverQuestionProps = useCoverQuestionProps(() => {}, question);
 
-  const getSelectInputProps = useSelectInputProps(
+  const { getSelectInputProps, selected: selectQuestionSelectedOptions } = useSelectInputProps(
     () => {},
     () => {},
     question
@@ -232,6 +247,7 @@ export const useMockContextValue = (
     getCoverQuestionProps,
     getOpenTextInputProps,
     getSelectInputProps,
+    selectQuestionSelectedOptions,
     getAddToCartButtonProps: () => ({
       ...mockElementProps,
       className: 'cio-result-card-cta-button',

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ import ConstructorIOClient, {
 import { RequestStates } from './constants';
 // eslint-disable-next-line import/no-cycle
 import { QuestionTypes } from './components/CioQuiz/actions';
+import { Selected } from './components/SelectTypeQuestion/SelectTypeQuestion';
 
 export type {
   QuestionOption,
@@ -393,6 +394,7 @@ export interface UseQuizReturn {
   getQuizResultButtonProps: GetQuizResultButtonProps;
   getQuizResultLinkProps: GetQuizResultLinkProps;
   getJumpToQuestionButtonProps: GetJumpToQuestionButtonProps;
+  selectQuestionSelectedOptions: Selected;
   primaryColorStyles: PrimaryColorStyles;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,7 @@ import { RequestStates } from './constants';
 import { QuestionTypes } from './components/CioQuiz/actions';
 
 export interface Selected {
-  [key: number]: boolean;
+  [key: string]: boolean;
 }
 
 export type {

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,10 @@ import ConstructorIOClient, {
 import { RequestStates } from './constants';
 // eslint-disable-next-line import/no-cycle
 import { QuestionTypes } from './components/CioQuiz/actions';
-import { Selected } from './components/SelectTypeQuestion/SelectTypeQuestion';
+
+export interface Selected {
+  [key: number]: boolean;
+}
 
 export type {
   QuestionOption,

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -2,8 +2,7 @@
 import React from 'react';
 import { QuestionTypes } from './components/CioQuiz/actions';
 import { QuizLocalReducerState } from './components/CioQuiz/quizLocalReducer';
-import { Selected } from './components/SelectTypeQuestion/SelectTypeQuestion';
-import { PrimaryColorStyles, Question, QuestionImages } from './types';
+import { PrimaryColorStyles, Question, QuestionImages, Selected } from './types';
 
 export const renderImages = (images: Partial<QuestionImages>, cssClasses?: string) => {
   const {
@@ -261,9 +260,7 @@ export function getDisplayedDescription(
   const selectedIds = Object.keys(selected).filter((id) => selected[Number(id)]);
   if (selectedIds.length !== 1) return question?.description;
 
-  const selectedOption = question?.options?.find(
-    (opt) => String(opt.id) === selectedIds[0]
-  );
+  const selectedOption = question?.options?.find((opt) => String(opt.id) === selectedIds[0]);
 
   return selectedOption?.description || question?.description;
 }

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -2,7 +2,8 @@
 import React from 'react';
 import { QuestionTypes } from './components/CioQuiz/actions';
 import { QuizLocalReducerState } from './components/CioQuiz/quizLocalReducer';
-import { PrimaryColorStyles, QuestionImages } from './types';
+import { Selected } from './components/SelectTypeQuestion/SelectTypeQuestion';
+import { PrimaryColorStyles, Question, QuestionImages } from './types';
 
 export const renderImages = (images: Partial<QuestionImages>, cssClasses?: string) => {
   const {
@@ -246,4 +247,23 @@ export function getNestedValueUsingDotNotation(object: any, key?: string): unkno
   }
 
   return key.split('.').reduce((a, b) => a?.[b], object);
+}
+
+export function getDisplayedDescription(
+  question: Question | null | undefined,
+  selected: Selected
+): string | undefined {
+  if (!question?.description && !question?.options) return undefined;
+
+  const { isSingleQuestion } = getQuestionTypes(question?.type);
+  if (!isSingleQuestion) return question?.description;
+
+  const selectedIds = Object.keys(selected).filter((id) => selected[Number(id)]);
+  if (selectedIds.length !== 1) return question?.description;
+
+  const selectedOption = question?.options?.find(
+    (opt) => String(opt.id) === selectedIds[0]
+  );
+
+  return selectedOption?.description || question?.description;
 }

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -257,10 +257,11 @@ export function getDisplayedDescription(
   const { isSingleQuestion } = getQuestionTypes(question?.type);
   if (!isSingleQuestion) return question?.description;
 
-  const selectedIds = Object.keys(selected).filter((id) => selected[Number(id)]);
-  if (selectedIds.length !== 1) return question?.description;
+  const selectedEntries = Object.entries(selected).filter(([, isSelected]) => Boolean(isSelected));
+  if (selectedEntries.length !== 1) return question?.description;
 
-  const selectedOption = question?.options?.find((opt) => String(opt.id) === selectedIds[0]);
+  const [selectedId] = selectedEntries[0];
+  const selectedOption = question?.options?.find((opt) => String(opt.id) === selectedId);
 
   return selectedOption?.description || question?.description;
 }

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -256,7 +256,7 @@ export function getDisplayedDescription(
 
   const { isSingleQuestion, isSingleFilterQuestion } = getQuestionTypes(question?.type);
   if (!isSingleQuestion && !isSingleFilterQuestion) {
-     return question?.description;
+    return question?.description;
   }
 
   const selectedEntries = Object.entries(selected).filter(([, isSelected]) => Boolean(isSelected));

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -252,7 +252,7 @@ export function getDisplayedDescription(
   question: Question | null | undefined,
   selected: Selected
 ): string | undefined {
-  if (!question?.description && !question?.options) return undefined;
+  if (!question) return undefined;
 
   const { isSingleQuestion, isSingleFilterQuestion } = getQuestionTypes(question?.type);
   if (!isSingleQuestion && !isSingleFilterQuestion) {

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -254,11 +254,15 @@ export function getDisplayedDescription(
 ): string | undefined {
   if (!question?.description && !question?.options) return undefined;
 
-  const { isSingleQuestion } = getQuestionTypes(question?.type);
-  if (!isSingleQuestion) return question?.description;
+  const { isSingleQuestion, isSingleFilterQuestion } = getQuestionTypes(question?.type);
+  if (!isSingleQuestion && !isSingleFilterQuestion) {
+     return question?.description;
+  }
 
   const selectedEntries = Object.entries(selected).filter(([, isSelected]) => Boolean(isSelected));
-  if (selectedEntries.length !== 1) return question?.description;
+  if (selectedEntries.length !== 1) {
+    return question?.description;
+  }
 
   const [selectedId] = selectedEntries[0];
   const selectedOption = question?.options?.find((opt) => String(opt.id) === selectedId);


### PR DESCRIPTION
Add support for displaying option-level descriptions in single-select quiz questions
When a single option with a description is selected, the question description area shows the option's description instead of the question-level description
Disable auto-advance to next question when the selected option has a description (user must click Continue)

Test plan
- Single-select question: click option with description → description text updates to option's description
- Single-select question: click option without description → shows original question description
- Single-select question with description option: auto-advance does NOT trigger, user clicks Continue
- Single-select question without description options: auto-advance works as before
- Multiple-select questions: no behavior change
- Cover/OpenText questions: no behavior change