### PR TITLE
[AT-82]: quizzes asa message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@constructor-io/constructorio-client-javascript": "^2.73.1",
+        "@constructor-io/constructorio-client-javascript": "^2.86.0",
         "react": ">=16.12.0",
         "react-dom": ">=16.12.0",
         "tslib": "^2.4.0"
@@ -2042,10 +2042,9 @@
       "dev": true
     },
     "node_modules/@constructor-io/constructorio-client-javascript": {
-      "version": "2.73.1",
-      "resolved": "https://registry.npmjs.org/@constructor-io/constructorio-client-javascript/-/constructorio-client-javascript-2.73.1.tgz",
-      "integrity": "sha512-IhLiRs+ZXUvCp9MRkts9LuZZyJJcW/UZ2bQBkY8iWnbZtw/sudfZiZ6a/khRqKX68Lb8+mXsXoAOikBZGSYRNA==",
-      "license": "MIT",
+      "version": "2.86.0",
+      "resolved": "https://registry.npmjs.org/@constructor-io/constructorio-client-javascript/-/constructorio-client-javascript-2.86.0.tgz",
+      "integrity": "sha512-7qO56XWaZnN/h5LMaltEt9zYwW6MFxTZhEP2hGs3UxvGFH+3EbYhZU7OG+aZ/RuNnA1AJLN/BkCqDUQ+3S33Zg==",
       "peer": true,
       "dependencies": {
         "@constructor-io/constructorio-id": "^2.6.0",
@@ -20283,9 +20282,9 @@
       "dev": true
     },
     "@constructor-io/constructorio-client-javascript": {
-      "version": "2.73.1",
-      "resolved": "https://registry.npmjs.org/@constructor-io/constructorio-client-javascript/-/constructorio-client-javascript-2.73.1.tgz",
-      "integrity": "sha512-IhLiRs+ZXUvCp9MRkts9LuZZyJJcW/UZ2bQBkY8iWnbZtw/sudfZiZ6a/khRqKX68Lb8+mXsXoAOikBZGSYRNA==",
+      "version": "2.86.0",
+      "resolved": "https://registry.npmjs.org/@constructor-io/constructorio-client-javascript/-/constructorio-client-javascript-2.86.0.tgz",
+      "integrity": "sha512-7qO56XWaZnN/h5LMaltEt9zYwW6MFxTZhEP2hGs3UxvGFH+3EbYhZU7OG+aZ/RuNnA1AJLN/BkCqDUQ+3S33Zg==",
       "peer": true,
       "requires": {
         "@constructor-io/constructorio-id": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "check-license": "license-checker --production --onlyAllow 'Apache-2.0;BSD-3-Clause;MIT;0BSD;BSD-2-Clause' --excludePackages 'picocolors@1.0.0'"
   },
   "peerDependencies": {
-    "@constructor-io/constructorio-client-javascript": "^2.73.1",
+    "@constructor-io/constructorio-client-javascript": "^2.86.0",
     "react": ">=16.12.0",
     "react-dom": ">=16.12.0",
     "tslib": "^2.4.0"

--- a/spec/components/QuizResultsSummary/QuizResultsSummary.server.test.tsx
+++ b/spec/components/QuizResultsSummary/QuizResultsSummary.server.test.tsx
@@ -60,4 +60,24 @@ describe(`${QuizResultsSummary.name} client`, () => {
     );
     expect(view).toContain('');
   });
+
+  describe('with asaMessage', () => {
+    it('renders ASA message instead of matched options', () => {
+      const view = renderToString(
+        <QuizResultsSummary {...props} asaMessage='Here are some great products for you' />
+      );
+      expect(view).toContain('Here are some great products for you');
+      expect(view).not.toContain('MATCHED_OPTION_1');
+    });
+
+    it('renders default summary when asaMessage is null', () => {
+      const view = renderToString(<QuizResultsSummary {...props} asaMessage={null} />);
+      expect(view).toContain('MATCHED_OPTION_1 $ MATCHED_OPTION_2 and MATCHED_OPTION_3');
+    });
+
+    it('renders default summary when asaMessage is not provided', () => {
+      const view = renderToString(<QuizResultsSummary {...props} />);
+      expect(view).toContain('MATCHED_OPTION_1 $ MATCHED_OPTION_2 and MATCHED_OPTION_3');
+    });
+  });
 });

--- a/spec/components/QuizResultsSummary/QuizResultsSummary.test.tsx
+++ b/spec/components/QuizResultsSummary/QuizResultsSummary.test.tsx
@@ -65,4 +65,28 @@ describe(`${QuizResultsSummary.name} client`, () => {
     );
     expect(container).toBeEmptyDOMElement();
   });
+
+  describe('with asaMessage', () => {
+    it('renders ASA message instead of matched options', () => {
+      render(
+        <QuizResultsSummary {...props} asaMessage='Here are some great products for you' />
+      );
+      expect(screen.getByText('Here are some great products for you')).toBeInTheDocument();
+      expect(screen.queryByText('MATCHED_OPTION_1')).not.toBeInTheDocument();
+    });
+
+    it('renders default summary when asaMessage is null', () => {
+      render(<QuizResultsSummary {...props} asaMessage={null} />);
+      expect(
+        screen.getByText('MATCHED_OPTION_1 $ MATCHED_OPTION_2 and MATCHED_OPTION_3')
+      ).toBeInTheDocument();
+    });
+
+    it('renders default summary when asaMessage is not provided', () => {
+      render(<QuizResultsSummary {...props} />);
+      expect(
+        screen.getByText('MATCHED_OPTION_1 $ MATCHED_OPTION_2 and MATCHED_OPTION_3')
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/spec/components/ResultFiltersAndShare/ResultFiltersAndShare.test.tsx
+++ b/spec/components/ResultFiltersAndShare/ResultFiltersAndShare.test.tsx
@@ -5,6 +5,7 @@ import ResultFiltersAndShare from '../../../src/components/ResultFiltersAndShare
 import { withContext } from '../../__tests__/utils';
 import { QuizContextValue } from '../../../src/components/CioQuiz/context';
 import { QuizReturnState } from '../../../src/types';
+import { RequestStates } from '../../../src/constants';
 
 describe(`${ResultFiltersAndShare.name} client`, () => {
   const props: React.ComponentProps<typeof ResultFiltersAndShare> = {
@@ -69,6 +70,39 @@ describe(`${ResultFiltersAndShare.name} client`, () => {
     it('renders results', () => {
       render(<Subject {...props} numberOfResults={2} />);
       expect(screen.getByText('2 results')).toBeInTheDocument();
+    });
+  });
+
+  describe('with ASA results message', () => {
+    const contextMocks: Partial<QuizContextValue> = {
+      state: {
+        quiz: {
+          requestState: RequestStates.Success,
+          matchedOptions: ['MATCHED_OPTION_1', 'MATCHED_OPTION_2'],
+          resultsConfig: null,
+          results: {
+            quiz_asa_results_message: 'Here are some great products for you',
+            quiz_id: 'test-quiz',
+            quiz_version_id: 'v1',
+            quiz_session_id: 'session-1',
+            quiz_selected_options: [],
+          },
+        } as QuizReturnState['quiz'],
+      } as QuizContextValue['state'],
+    };
+
+    const Subject = withContext(ResultFiltersAndShare, { contextMocks });
+
+    it('renders the ASA message', () => {
+      render(<Subject {...props} />);
+      expect(
+        screen.getByText('Here are some great products for you')
+      ).toBeInTheDocument();
+    });
+
+    it('does not render default matched options text', () => {
+      render(<Subject {...props} />);
+      expect(screen.queryByText(/Based on your answers/)).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/QuizResultsSummary/QuizResultsSummary.tsx
+++ b/src/components/QuizResultsSummary/QuizResultsSummary.tsx
@@ -6,6 +6,7 @@ import { QuizResultsConfig } from '../../types';
 interface QuizResultsSummaryProps {
   summary: QuizResultsConfig['desktop']['response_summary'];
   matchedOptions?: string[];
+  asaMessage?: string | null;
 }
 
 const getSummaryVariables = ({ summary, matchedOptions = [] }: QuizResultsSummaryProps) => {
@@ -40,7 +41,12 @@ const getSummaryVariables = ({ summary, matchedOptions = [] }: QuizResultsSummar
 export default function QuizResultsSummary({
   summary,
   matchedOptions = [],
+  asaMessage,
 }: QuizResultsSummaryProps) {
+  if (asaMessage) {
+    return <p className='cio-results-explanation'>{asaMessage}</p>;
+  }
+
   const { summaryFirstPart, summaryLastPart, itemsSeparator, lastSeparator, isActiveSummary } =
     getSummaryVariables({ summary, matchedOptions });
 

--- a/src/components/ResultFiltersAndShare/ResultFiltersAndShare.tsx
+++ b/src/components/ResultFiltersAndShare/ResultFiltersAndShare.tsx
@@ -2,6 +2,7 @@ import React, { useContext } from 'react';
 import QuizContext from '../CioQuiz/context';
 import ShareButton from '../ShareButton/ShareButton';
 import QuizResultsSummary from '../QuizResultsSummary/QuizResultsSummary';
+import { QuizResultsResponse } from '../../types';
 
 interface ResultFiltersAndShareProps {
   onShare: () => void;
@@ -17,11 +18,13 @@ function ResultFiltersAndShare({
   const { state } = useContext(QuizContext);
   const matchedOptions = state?.quiz?.matchedOptions;
   const summary = state?.quiz?.resultsConfig?.desktop?.response_summary ?? null;
+  const asaMessage =
+    (state?.quiz?.results as QuizResultsResponse | undefined)?.quiz_asa_results_message ?? null;
 
   return (
     <div className='cio-results-filter-and-redo-container cio-results-button-group'>
       <div className='cio-results-filter-container'>
-        <QuizResultsSummary summary={summary} matchedOptions={matchedOptions} />
+        <QuizResultsSummary summary={summary} matchedOptions={matchedOptions} asaMessage={asaMessage} />
       </div>
       <div className='cio-results-number-and-share-button-group'>
         {numberOfResults} {numberOfResults === 1 ? 'result' : 'results'}

--- a/src/components/ResultFiltersAndShare/ResultFiltersAndShare.tsx
+++ b/src/components/ResultFiltersAndShare/ResultFiltersAndShare.tsx
@@ -25,7 +25,11 @@ function ResultFiltersAndShare({
   const matchedOptions = state?.quiz?.matchedOptions;
   const summary = state?.quiz?.resultsConfig?.desktop?.response_summary ?? null;
   const results = state?.quiz?.results;
-  const asaMessage = (isQuizResultsResponse(results) && results.quiz_asa_results_message) || null;
+  const asaMessage =
+    (isQuizResultsResponse(results) &&
+      typeof results.quiz_asa_results_message === 'string' &&
+      results.quiz_asa_results_message) ||
+    null;
 
   return (
     <div className='cio-results-filter-and-redo-container cio-results-button-group'>

--- a/src/components/ResultFiltersAndShare/ResultFiltersAndShare.tsx
+++ b/src/components/ResultFiltersAndShare/ResultFiltersAndShare.tsx
@@ -24,7 +24,11 @@ function ResultFiltersAndShare({
   return (
     <div className='cio-results-filter-and-redo-container cio-results-button-group'>
       <div className='cio-results-filter-container'>
-        <QuizResultsSummary summary={summary} matchedOptions={matchedOptions} asaMessage={asaMessage} />
+        <QuizResultsSummary
+          summary={summary}
+          matchedOptions={matchedOptions}
+          asaMessage={asaMessage}
+        />
       </div>
       <div className='cio-results-number-and-share-button-group'>
         {numberOfResults} {numberOfResults === 1 ? 'result' : 'results'}

--- a/src/components/ResultFiltersAndShare/ResultFiltersAndShare.tsx
+++ b/src/components/ResultFiltersAndShare/ResultFiltersAndShare.tsx
@@ -2,7 +2,13 @@ import React, { useContext } from 'react';
 import QuizContext from '../CioQuiz/context';
 import ShareButton from '../ShareButton/ShareButton';
 import QuizResultsSummary from '../QuizResultsSummary/QuizResultsSummary';
-import { QuizResultsResponse } from '../../types';
+import { QuizResultsResponse, QuizSharedResultsData } from '../../types';
+
+function isQuizResultsResponse(
+  results: QuizResultsResponse | QuizSharedResultsData | undefined
+): results is QuizResultsResponse {
+  return !!results && 'quiz_id' in results;
+}
 
 interface ResultFiltersAndShareProps {
   onShare: () => void;
@@ -18,8 +24,9 @@ function ResultFiltersAndShare({
   const { state } = useContext(QuizContext);
   const matchedOptions = state?.quiz?.matchedOptions;
   const summary = state?.quiz?.resultsConfig?.desktop?.response_summary ?? null;
+  const results = state?.quiz?.results;
   const asaMessage =
-    (state?.quiz?.results as QuizResultsResponse | undefined)?.quiz_asa_results_message ?? null;
+    (isQuizResultsResponse(results) && results.quiz_asa_results_message) || null;
 
   return (
     <div className='cio-results-filter-and-redo-container cio-results-button-group'>

--- a/src/components/ResultFiltersAndShare/ResultFiltersAndShare.tsx
+++ b/src/components/ResultFiltersAndShare/ResultFiltersAndShare.tsx
@@ -7,7 +7,7 @@ import { QuizResultsResponse, QuizSharedResultsData } from '../../types';
 function isQuizResultsResponse(
   results: QuizResultsResponse | QuizSharedResultsData | undefined
 ): results is QuizResultsResponse {
-  return !!results && 'quiz_id' in results;
+  return !!results && 'quiz_selected_options' in results;
 }
 
 interface ResultFiltersAndShareProps {

--- a/src/components/ResultFiltersAndShare/ResultFiltersAndShare.tsx
+++ b/src/components/ResultFiltersAndShare/ResultFiltersAndShare.tsx
@@ -25,8 +25,7 @@ function ResultFiltersAndShare({
   const matchedOptions = state?.quiz?.matchedOptions;
   const summary = state?.quiz?.resultsConfig?.desktop?.response_summary ?? null;
   const results = state?.quiz?.results;
-  const asaMessage =
-    (isQuizResultsResponse(results) && results.quiz_asa_results_message) || null;
+  const asaMessage = (isQuizResultsResponse(results) && results.quiz_asa_results_message) || null;
 
   return (
     <div className='cio-results-filter-and-redo-container cio-results-button-group'>

--- a/src/stories/Quiz/Component/QuizResults/QuizResults.stories.tsx
+++ b/src/stories/Quiz/Component/QuizResults/QuizResults.stories.tsx
@@ -6,6 +6,7 @@ import { resultCardOptions } from '../../tests/mocks';
 import QuizResultsVariationsDecorator, {
   QuizResultsPrimaryDecorator,
   QuizResultsWithSummaryDecorator,
+  QuizResultsWithAsaMessageDecorator,
 } from './QuizResultsDecorator';
 
 const meta: Meta<typeof ResultContainer> = {
@@ -51,4 +52,16 @@ export const QuizResultsPageWithSummary: Story = {
     </div>
   ),
   decorators: [(story) => QuizResultsWithSummaryDecorator(story)],
+};
+
+export const QuizResultsPageWithAsaMessage: Story = {
+  args: {
+    resultCardOptions,
+  },
+  render: (args) => (
+    <div className='results-example-wrapper'>
+      <ResultContainer resultCardOptions={resultCardOptions} onShare={args.onShare} />
+    </div>
+  ),
+  decorators: [(story) => QuizResultsWithAsaMessageDecorator(story)],
 };

--- a/src/stories/Quiz/Component/QuizResults/QuizResultsDecorator.tsx
+++ b/src/stories/Quiz/Component/QuizResults/QuizResultsDecorator.tsx
@@ -51,6 +51,23 @@ export function QuizResultsWithSummaryDecorator(Story: any) {
   );
 }
 
+export function QuizResultsWithAsaMessageDecorator(Story: any) {
+  const contextValue = useMockContextValue(undefined, {
+    asaMessage:
+      'Here are some perfect coffee options to energize your mornings with rich flavor and smooth taste.',
+  });
+
+  return (
+    <div className='cio-quiz'>
+      <QuizContext.Provider value={contextValue}>
+        <div>
+          <StoryPreview Component={Story} />
+        </div>
+      </QuizContext.Provider>
+    </div>
+  );
+}
+
 function ZeroResultsComponent() {
   return <ZeroResults />;
 }

--- a/src/stories/Quiz/tests/mocks.tsx
+++ b/src/stories/Quiz/tests/mocks.tsx
@@ -20,7 +20,7 @@ import useSelectInputProps from '../../../hooks/usePropsGetters/useSelectInputPr
 
 type MockOptions = {
   withSummary?: boolean;
-  asaMessage?: string | null;
+  asaMessage?: string;
 };
 
 export const getMockQuestion = (type: `${QuestionTypes}`) => ({

--- a/src/stories/Quiz/tests/mocks.tsx
+++ b/src/stories/Quiz/tests/mocks.tsx
@@ -19,7 +19,8 @@ import useCoverQuestionProps from '../../../hooks/usePropsGetters/useCoverQuesti
 import useSelectInputProps from '../../../hooks/usePropsGetters/useSelectInputProps';
 
 type MockOptions = {
-  withSummary: boolean;
+  withSummary?: boolean;
+  asaMessage?: string | null;
 };
 
 export const getMockQuestion = (type: `${QuestionTypes}`) => ({
@@ -164,6 +165,9 @@ export const getMockState = (question?: Question, options?: MockOptions): QuizRe
         { value: 'Potato', has_attribute: true, is_matched: true },
         { value: 'Medium', has_attribute: true, is_matched: false },
       ],
+      ...(options?.asaMessage !== undefined && {
+        quiz_asa_results_message: options.asaMessage,
+      }),
     },
     selectedOptionsWithAttributes: ['Chocolate', 'Medium'],
     matchedOptions: ['Chocolate', 'Milk', 'Medium', 'Cacao'],


### PR DESCRIPTION
**Summary**
* Display `quiz_asa_results_message` from the quiz results API response instead of the default response summary ("Based on your answers...") on the results page
* Falls back to the existing matched-options summary when the field is null or absent
* Added Storybook story to preview the ASA message behavior

**Test plan**
*  Verify ASA message renders when quiz_asa_results_message is present in the API response
*  Verify default response summary renders when quiz_asa_results_message is null
*  Verify default response summary renders when quiz_asa_results_message is absent from the response
*  Check Storybook story QuizResultsPageWithAsaMessage displays the ASA message correctly


<img width="774" height="697" alt="Here are your results" src="https://github.com/user-attachments/assets/42506d3c-1447-40a6-bd56-fb1bc9a2af3a" />
