### PR TITLE
[AT-170]: support option descriptions in multiple select

### DIFF
--- a/spec/components/SelectTypeQuestion/SelectTypeQuestion.server.test.tsx
+++ b/spec/components/SelectTypeQuestion/SelectTypeQuestion.server.test.tsx
@@ -97,6 +97,53 @@ describe(`${SelectTypeQuestion.name} client`, () => {
     });
   });
 
+  describe('multiple select with option descriptions', () => {
+    const question = factories.selectQuestion.build({
+      type: QuestionTypes.MultipleSelect,
+      options: [
+        factories.selectOption.build({ description: 'OPTION DESCRIPTION' }),
+        factories.selectOption.build({ description: null }),
+      ],
+    });
+    const Subject = withContext(SelectTypeQuestion, {
+      contextMocks: {
+        getSelectInputProps: getSelectInputPropsMock,
+        state: {
+          quiz: {
+            currentQuestion: { next_question: question } as CurrentQuestion,
+          } as QuizReturnState['quiz'],
+        } as QuizContextValue['state'],
+      },
+    });
+
+    it('renders the description of the options that have one', () => {
+      const view = renderToString(<Subject />);
+      expect(view).toContain('OPTION DESCRIPTION');
+      expect(view).toContain('cio-question-option-description');
+    });
+  });
+
+  describe('single select with option descriptions', () => {
+    const question = factories.selectQuestion.build({
+      options: factories.selectOption.buildList(2, { description: 'OPTION DESCRIPTION' }),
+    });
+    const Subject = withContext(SelectTypeQuestion, {
+      contextMocks: {
+        getSelectInputProps: getSelectInputPropsMock,
+        state: {
+          quiz: {
+            currentQuestion: { next_question: question } as CurrentQuestion,
+          } as QuizReturnState['quiz'],
+        } as QuizContextValue['state'],
+      },
+    });
+
+    it('does not render option descriptions inside the option cards', () => {
+      const view = renderToString(<Subject />);
+      expect(view).not.toContain('cio-question-option-description');
+    });
+  });
+
   describe('when question is null', () => {
     const Subject = withContext(SelectTypeQuestion, {
       contextMocks: {

--- a/spec/components/SelectTypeQuestion/SelectTypeQuestion.test.tsx
+++ b/spec/components/SelectTypeQuestion/SelectTypeQuestion.test.tsx
@@ -99,6 +99,54 @@ describe(`${SelectTypeQuestion.name} client`, () => {
     });
   });
 
+  describe('multiple select with option descriptions', () => {
+    const question = factories.selectQuestion.build({
+      type: QuestionTypes.MultipleSelect,
+      options: [
+        factories.selectOption.build({ description: 'OPTION DESCRIPTION' }),
+        factories.selectOption.build({ description: null }),
+      ],
+    });
+    const Subject = withContext(SelectTypeQuestion, {
+      contextMocks: {
+        getSelectInputProps: getSelectInputPropsMock,
+        state: {
+          quiz: {
+            currentQuestion: { next_question: question } as CurrentQuestion,
+          } as QuizReturnState['quiz'],
+        } as QuizContextValue['state'],
+      },
+    });
+
+    it('renders the description of the options that have one', () => {
+      const { container } = render(<Subject />);
+      expect(screen.getByText('OPTION DESCRIPTION')).toBeInTheDocument();
+      expect(container.querySelectorAll('.cio-question-option-description')).toHaveLength(1);
+    });
+  });
+
+  describe('single select with option descriptions', () => {
+    const question = factories.selectQuestion.build({
+      options: factories.selectOption.buildList(2, { description: 'OPTION DESCRIPTION' }),
+    });
+    const Subject = withContext(SelectTypeQuestion, {
+      contextMocks: {
+        getSelectInputProps: getSelectInputPropsMock,
+        state: {
+          quiz: {
+            currentQuestion: { next_question: question } as CurrentQuestion,
+          } as QuizReturnState['quiz'],
+        } as QuizContextValue['state'],
+      },
+    });
+
+    it('does not render option descriptions inside the option cards', () => {
+      const { container } = render(<Subject />);
+      expect(screen.queryByText('OPTION DESCRIPTION')).not.toBeInTheDocument();
+      expect(container.querySelectorAll('.cio-question-option-description')).toHaveLength(0);
+    });
+  });
+
   describe('with image', () => {
     const Subject = withContext(SelectTypeQuestion, {
       contextMocks: {

--- a/src/components/SelectTypeQuestion/SelectTypeQuestion.tsx
+++ b/src/components/SelectTypeQuestion/SelectTypeQuestion.tsx
@@ -15,11 +15,15 @@ function SelectTypeQuestion() {
   } = useContext(QuizContext);
   let question: Nullable<Question> | undefined;
   let hasImages = false;
+  let hasOptionDescriptions = false;
   let instructions;
 
   if (state?.quiz.currentQuestion) {
     question = state.quiz.currentQuestion.next_question;
     hasImages = question?.options.some((option: QuestionOption) => option.images);
+    hasOptionDescriptions =
+      question?.type === QuestionTypes.MultipleSelect &&
+      question.options.some((option: QuestionOption) => Boolean(option.description));
     instructions =
       (question?.type === QuestionTypes.MultipleSelect ||
         question.type === QuestionTypes.MultipleFilterValues) &&
@@ -44,13 +48,18 @@ function SelectTypeQuestion() {
             !hasImages
               ? 'cio-question-options-container-text-only'
               : 'cio-question-options-container'
-          }`}>
+          }${hasOptionDescriptions ? ' cio-question-options-container-with-descriptions' : ''}`}>
           {question?.options?.map(
             (option: QuestionOption) =>
               getSelectInputProps && (
                 <div {...getSelectInputProps(option)}>
                   {option.images ? renderImages(option.images, 'cio-question-option-image') : ''}
                   <div className='cio-question-option-value'>{option?.value}</div>
+                  {hasOptionDescriptions && option.description ? (
+                    <div className='cio-question-option-description'>{option.description}</div>
+                  ) : (
+                    ''
+                  )}
                 </div>
               )
           )}

--- a/src/stories/Quiz/Component/QuestionTypes/MultipleSelectQuestion.stories.tsx
+++ b/src/stories/Quiz/Component/QuestionTypes/MultipleSelectQuestion.stories.tsx
@@ -8,6 +8,7 @@ import {
   getMockQuestion,
   questionOptionsWithImages,
   questionOptions,
+  questionOptionsWithDescriptions,
 } from '../../tests/mocks';
 import QuestionTypeVariationsDecorator, {
   QuestionTypePrimaryDecorator,
@@ -20,6 +21,17 @@ const multipleSelectQuestionWithImages = {
 const multipleSelectQuestionWithoutImages = {
   ...getMockQuestion(QuestionTypes.MultipleSelect),
   options: questionOptions,
+};
+const multipleSelectQuestionWithDescriptions = {
+  ...getMockQuestion(QuestionTypes.MultipleSelect),
+  options: questionOptionsWithDescriptions,
+};
+const multipleSelectQuestionWithImagesAndDescriptions = {
+  ...getMockQuestionWithImage(QuestionTypes.MultipleSelect),
+  options: questionOptionsWithImages.map((option, index) => ({
+    ...option,
+    description: questionOptionsWithDescriptions[index]?.description,
+  })),
 };
 
 const meta: Meta<typeof SelectTypeQuestion> = {
@@ -50,6 +62,24 @@ export const WithoutImages: Story = {
     (story) =>
       QuestionTypeVariationsDecorator(story, [
         multipleSelectQuestionWithoutImages as SelectQuestion,
+      ]),
+  ],
+};
+
+export const WithOptionDescriptions: Story = {
+  decorators: [
+    (story) =>
+      QuestionTypePrimaryDecorator(story, [
+        multipleSelectQuestionWithDescriptions as SelectQuestion,
+      ]),
+  ],
+};
+
+export const WithImagesAndOptionDescriptions: Story = {
+  decorators: [
+    (story) =>
+      QuestionTypePrimaryDecorator(story, [
+        multipleSelectQuestionWithImagesAndDescriptions as SelectQuestion,
       ]),
   ],
 };

--- a/src/stories/Quiz/Component/QuestionTypes/QuestionTypeDecorator.tsx
+++ b/src/stories/Quiz/Component/QuestionTypes/QuestionTypeDecorator.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { Question } from '@constructor-io/constructorio-client-javascript/lib/types';
+import { Question } from '@constructor-io/constructorio-client-javascript/lib/types/quizzes';
 import QuizContext from '../../../../components/CioQuiz/context';
 import { useMockContextValue } from '../../tests/mocks';
 import StoryPreview from '../../utils/StoryPreview';

--- a/src/stories/Quiz/tests/mocks.tsx
+++ b/src/stories/Quiz/tests/mocks.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { Question } from '@constructor-io/constructorio-client-javascript/lib/types';
+import { Question } from '@constructor-io/constructorio-client-javascript/lib/types/quizzes';
 import { quizSessionStateKey, RequestStates } from '../../../constants';
 import {
   Callbacks,
@@ -120,6 +120,7 @@ export const getMockState = (question?: Question, options?: MockOptions): QuizRe
       isMultipleQuestion: question?.type === QuestionTypes.MultipleSelect,
       isSingleFilterQuestion: question?.type === QuestionTypes.SingleFilterValue,
       isMultipleFilterQuestion: question?.type === QuestionTypes.MultipleFilterValues,
+      isFreeFormQuestion: question?.type === QuestionTypes.FreeForm,
       isSelectQuestion: question?.type === QuestionTypes.SingleSelect,
       total_questions: 1,
     },

--- a/src/styles.css
+++ b/src/styles.css
@@ -414,9 +414,7 @@
   text-align: center;
   margin: auto 0;
 }
-.cio-quiz .cio-question-options-container-with-descriptions .cio-question-option-value,
-.cio-quiz .cio-question-options-container-text-only.cio-question-options-container-with-descriptions
-  .cio-question-option-value {
+.cio-quiz .cio-question-options-container-with-descriptions .cio-question-option-value {
   margin: 0;
 }
 
@@ -424,6 +422,7 @@
 .cio-quiz .cio-question-option-description {
   display: -webkit-box;
   -webkit-line-clamp: 2;
+  line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
   margin-top: 0.5rem;

--- a/src/styles.css
+++ b/src/styles.css
@@ -414,6 +414,25 @@
   text-align: center;
   margin: auto 0;
 }
+.cio-quiz .cio-question-options-container-with-descriptions .cio-question-option-value,
+.cio-quiz .cio-question-options-container-text-only.cio-question-options-container-with-descriptions
+  .cio-question-option-value {
+  margin: 0;
+}
+
+/* Select Option Description */
+.cio-quiz .cio-question-option-description {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+  font-style: italic;
+  line-height: 150%;
+  text-align: center;
+  color: var(--gray-dust-100);
+}
 
 /* Select Text and Description */
 .cio-quiz .cio-select-question-text {


### PR DESCRIPTION
Added option-level descriptions for multiple-select quiz questions, mirroring the feature that already existed for single-select but with a different presentation.


- /?path=/story/quiz-cioquiz-questions-multipleselectquestion--with-option-descriptions
<img width="1226" height="532" alt="image" src="https://github.com/user-attachments/assets/a7281f48-58d6-41dd-a209-ac51dad99583" />

-  /?path=/story/quiz-cioquiz-questions-multipleselectquestion--with-images-and-option-descriptions
<img width="1208" height="518" alt="image" src="https://github.com/user-attachments/assets/59a0874c-1b8d-4b85-a886-66fe6d938666" />
